### PR TITLE
🔒 Fix insecure temporary file deletion in PlantUmlRenderer

### DIFF
--- a/src/main/java/com/huq/idea/flow/util/PlantUmlRenderer.java
+++ b/src/main/java/com/huq/idea/flow/util/PlantUmlRenderer.java
@@ -136,13 +136,16 @@ public class PlantUmlRenderer {
         try {
             // 创建临时目录
             tempDir = FileUtil.createTempDirectory("plantuml_", "_temp", true);
+            tempDir.deleteOnExit();
 
             // 创建临时PlantUML文件
             pumlFile = new File(tempDir, "diagram.puml");
+            pumlFile.deleteOnExit();
             Files.writeString(pumlFile.toPath(), plantUmlCode, StandardCharsets.UTF_8);
 
             // 输出PNG文件路径
             pngFile = new File(tempDir, "diagram.png");
+            pngFile.deleteOnExit();
 
             // 构建命令
             ProcessBuilder processBuilder = new ProcessBuilder(
@@ -219,13 +222,16 @@ public class PlantUmlRenderer {
         try {
             // 创建临时目录
             tempDir = FileUtil.createTempDirectory("plantuml_", "_temp", true);
+            tempDir.deleteOnExit();
 
             // 创建临时PlantUML文件
             pumlFile = new File(tempDir, "diagram.puml");
+            pumlFile.deleteOnExit();
             Files.writeString(pumlFile.toPath(), plantUmlCode, StandardCharsets.UTF_8);
 
             // 输出SVG文件路径
             svgFile = new File(tempDir, "diagram.svg");
+            svgFile.deleteOnExit();
 
             // 构建命令
             ProcessBuilder processBuilder = new ProcessBuilder(


### PR DESCRIPTION
This PR addresses a security vulnerability where temporary files and directories used during PlantUML rendering were not guaranteed to be deleted if the JVM exited unexpectedly. 

🎯 **What:** Added `deleteOnExit()` calls for all temporary file and directory objects in `PlantUmlRenderer.java`.
⚠️ **Risk:** Potentially sensitive PlantUML diagrams or generated images could remain on the system's temporary storage if the IDE or rendering process crashes, leading to unintended data exposure.
🛡️ **Solution:** By calling `deleteOnExit()` immediately after file creation, the JVM will attempt to delete these files during its shutdown sequence, providing a fallback for the existing `finally` cleanup logic.

The fix was applied to both PNG and SVG rendering paths to ensure consistency.


---
*PR created automatically by Jules for task [11470184817438858609](https://jules.google.com/task/11470184817438858609) started by @yisshengyouni*