### PR TITLE
🧹 [code health improvement] Use Logger instead of printStackTrace and System.err/out

### DIFF
--- a/src/main/java/com/huq/idea/flow/model/FlowGraphData.java
+++ b/src/main/java/com/huq/idea/flow/model/FlowGraphData.java
@@ -2,6 +2,7 @@ package com.huq.idea.flow.model;
 
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
+import com.intellij.openapi.diagnostic.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +14,8 @@ import java.util.List;
  * @since 2024/8/10
  */
 public class FlowGraphData {
+
+    private static final Logger LOG = Logger.getInstance(FlowGraphData.class);
 
     @SerializedName("nodes")
     private List<Node> nodes = new ArrayList<>();
@@ -44,7 +47,7 @@ public class FlowGraphData {
             Gson gson = new Gson();
             return gson.fromJson(json, FlowGraphData.class);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.error(e);
             // 如果解析失败，返回一个空的数据对象
             return new FlowGraphData();
         }

--- a/src/main/java/com/huq/idea/flow/view/PlanUMLUtil.java
+++ b/src/main/java/com/huq/idea/flow/view/PlanUMLUtil.java
@@ -14,10 +14,13 @@ import com.github.javaparser.ast.stmt.WhileStmt;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import com.huq.idea.flow.model.CallStack;
 import com.huq.idea.flow.model.MethodDescription;
+import com.intellij.openapi.diagnostic.Logger;
 
 import java.util.Optional;
 
 public class PlanUMLUtil {
+
+    private static final Logger LOG = Logger.getInstance(PlanUMLUtil.class);
 
 
     public static String format(CallStack callStack) {
@@ -142,7 +145,7 @@ public class PlanUMLUtil {
             plantUML.append("stop\n");
             plantUML.append("@enduml");
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOG.error(ex);
         }
     }
 
@@ -241,10 +244,10 @@ public class PlanUMLUtil {
             }, null);
 
             // 打印 BlockStmt 的内容
-            System.out.println(blockStmt);
+            LOG.debug(blockStmt.toString());
             return blockStmt;
         } else {
-            System.err.println("Failed to parse code snippet" + parseResult.getProblems());
+            LOG.error("Failed to parse code snippet" + parseResult.getProblems());
         }
         return null;
     }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the use of `ex.printStackTrace()` and `System.out.println`/`System.err.println` for error and debug information.

💡 **Why:** Replacing these with a proper logging framework (`com.intellij.openapi.diagnostic.Logger`) improves maintainability, as it allows for better log management (e.g., controlling log levels, redirecting logs to a file, etc.) and follows the standard practices for IntelliJ IDEA plugin development.

✅ **Verification:**
- Manually verified that the changes were correctly applied to `src/main/java/com/huq/idea/flow/view/PlanUMLUtil.java` and `src/main/java/com/huq/idea/flow/model/FlowGraphData.java` using `read_file`.
- A code review was performed, and the implementation was rated as correct and following project conventions.
- Attempted to run `./gradlew test`, but it failed due to network issues (timeout while downloading Gradle). However, there are no tests in `src/test/java`, so the risk of regression is minimal given the simple nature of the changes.

✨ **Result:** The codebase is now cleaner and follows better logging practices.

---
*PR created automatically by Jules for task [10351051195785142031](https://jules.google.com/task/10351051195785142031) started by @yisshengyouni*