### PR TITLE
🎨 Palette: [UX improvement] Add Accessibility (A11y) to Swing Configuration Component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-17 - Java Swing Accessibility (A11y) Patterns
+**Learning:** In Java Swing, simply placing a `JLabel` next to an input field (like `JTextField` or `JTextArea`) is insufficient for screen readers and keyboard accessibility. Screen readers won't know the context of the input, and keyboard users can't navigate to it quickly.
+**Action:** Always follow these steps when creating Swing forms:
+1. Extract inline `JLabel` initializations into variables.
+2. Use `label.setLabelFor(inputComponent)` to explicitly associate the label with its input.
+3. Assign a mnemonic using `label.setDisplayedMnemonic('X')` for keyboard navigation (Alt+X).
+4. Update the input component's tooltip with `setToolTipText("... (Alt+X)")` so users can discover the shortcut.

--- a/src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java
+++ b/src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java
@@ -138,7 +138,9 @@ public class AiConfigurationComponent {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         plantumlPathVal = new JTextField(30);
-        plantumlPathVal.setToolTipText("请输入PlantUML的安装路径");
+        plantumlPathVal.setToolTipText("请输入PlantUML的安装路径 (Alt+P)");
+        plantumlLabel.setLabelFor(plantumlPathVal);
+        plantumlLabel.setDisplayedMnemonic('P');
         generalConfigPanel.add(plantumlPathVal, gbc);
     }
     
@@ -174,27 +176,43 @@ public class AiConfigurationComponent {
         gbc.fill = GridBagConstraints.HORIZONTAL;
 
         gbc.gridx = 0; gbc.gridy = 0; gbc.weightx = 0;
-        rightPanel.add(new JLabel("名称:"), gbc);
+        JLabel nameLabel = new JLabel("名称:");
+        rightPanel.add(nameLabel, gbc);
         gbc.gridx = 1; gbc.weightx = 1.0;
         aiProviderNameField = new JTextField(30);
+        aiProviderNameField.setToolTipText("请输入名称 (Alt+N)");
+        nameLabel.setLabelFor(aiProviderNameField);
+        nameLabel.setDisplayedMnemonic('N');
         rightPanel.add(aiProviderNameField, gbc);
 
         gbc.gridx = 0; gbc.gridy = 1; gbc.weightx = 0;
-        rightPanel.add(new JLabel("域名代理 (URL):"), gbc);
+        JLabel urlLabel = new JLabel("域名代理 (URL):");
+        rightPanel.add(urlLabel, gbc);
         gbc.gridx = 1; gbc.weightx = 1.0;
         aiApiUrlField = new JTextField(30);
+        aiApiUrlField.setToolTipText("请输入域名代理URL (Alt+U)");
+        urlLabel.setLabelFor(aiApiUrlField);
+        urlLabel.setDisplayedMnemonic('U');
         rightPanel.add(aiApiUrlField, gbc);
 
         gbc.gridx = 0; gbc.gridy = 2; gbc.weightx = 0;
-        rightPanel.add(new JLabel("API Key:"), gbc);
+        JLabel apiKeyLabel = new JLabel("API Key:");
+        rightPanel.add(apiKeyLabel, gbc);
         gbc.gridx = 1; gbc.weightx = 1.0;
         aiApiKeyField = new JTextField(30);
+        aiApiKeyField.setToolTipText("请输入API Key (Alt+K)");
+        apiKeyLabel.setLabelFor(aiApiKeyField);
+        apiKeyLabel.setDisplayedMnemonic('K');
         rightPanel.add(aiApiKeyField, gbc);
 
         gbc.gridx = 0; gbc.gridy = 3; gbc.weightx = 0;
-        rightPanel.add(new JLabel("可用模型 (逗号分隔):"), gbc);
+        JLabel modelsLabel = new JLabel("可用模型 (逗号分隔):");
+        rightPanel.add(modelsLabel, gbc);
         gbc.gridx = 1; gbc.weightx = 1.0;
         aiModelsField = new JTextField(30);
+        aiModelsField.setToolTipText("请输入可用模型 (Alt+M)");
+        modelsLabel.setLabelFor(aiModelsField);
+        modelsLabel.setDisplayedMnemonic('M');
         rightPanel.add(aiModelsField, gbc);
 
         // Spacer
@@ -339,12 +357,15 @@ public class AiConfigurationComponent {
         // Right Panel: Text area for selected prompt
         JPanel rightPanel = new JPanel(new BorderLayout());
         flowPromptTextArea = new JTextArea(5, 30);
-        flowPromptTextArea.setToolTipText("自定义AI生成流程图的提示词");
+        flowPromptTextArea.setToolTipText("自定义AI生成流程图的提示词 (Alt+T)");
         flowPromptTextArea.setLineWrap(true);
         flowPromptTextArea.setWrapStyleWord(true);
         JScrollPane promptScrollPane = new JScrollPane(flowPromptTextArea);
         promptScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-        rightPanel.add(new JLabel("提示词内容:"), BorderLayout.NORTH);
+        JLabel promptContentLabel = new JLabel("提示词内容:");
+        promptContentLabel.setLabelFor(flowPromptTextArea);
+        promptContentLabel.setDisplayedMnemonic('T');
+        rightPanel.add(promptContentLabel, BorderLayout.NORTH);
         rightPanel.add(promptScrollPane, BorderLayout.CENTER);
 
         // Create Split Pane
@@ -439,7 +460,9 @@ public class AiConfigurationComponent {
         gbc.weightx = 1.0;
         gbc.weighty = 0.5;
         relevantPatternsArea = new JTextArea(3, 30);
-        relevantPatternsArea.setToolTipText("匹配相关类的正则表达式模式，每行一个");
+        relevantPatternsArea.setToolTipText("匹配相关类的正则表达式模式，每行一个 (Alt+R)");
+        relevantLabel.setLabelFor(relevantPatternsArea);
+        relevantLabel.setDisplayedMnemonic('R');
         relevantPatternsArea.setLineWrap(true);
         relevantPatternsArea.setWrapStyleWord(true);
         JScrollPane relevantScrollPane = new JScrollPane(relevantPatternsArea);
@@ -458,7 +481,9 @@ public class AiConfigurationComponent {
         gbc.weightx = 1.0;
         gbc.weighty = 0.5;
         excludedPatternsArea = new JTextArea(3, 30);
-        excludedPatternsArea.setToolTipText("排除类的正则表达式模式，每行一个");
+        excludedPatternsArea.setToolTipText("排除类的正则表达式模式，每行一个 (Alt+E)");
+        excludedLabel.setLabelFor(excludedPatternsArea);
+        excludedLabel.setDisplayedMnemonic('E');
         excludedPatternsArea.setLineWrap(true);
         excludedPatternsArea.setWrapStyleWord(true);
         JScrollPane excludedScrollPane = new JScrollPane(excludedPatternsArea);

--- a/test_a11y.sh
+++ b/test_a11y.sh
@@ -1,0 +1,1 @@
+grep -n "JLabel" src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java


### PR DESCRIPTION
💡 **What**: Added Java Swing accessibility (A11y) features to the `AiConfigurationComponent` by associating `JLabel` elements with their respective input fields, assigning mnemonics (Alt+Key combinations), and updating tooltips to indicate these shortcuts.

🎯 **Why**: To make the plugin's configuration interface more accessible to keyboard users and compatible with screen readers. Previously, screen readers couldn't properly interpret the context of input fields, and keyboard users lacked quick shortcuts to navigate forms.

📸 **Before/After**: 
*Before*: Input fields had standalone labels next to them.
*After*: Input fields have programmatically associated labels, keyboard shortcuts (like `Alt+P` for PlantUML), and tooltips displaying these shortcuts.

♿ **Accessibility**: Improved screen reader context by using `setLabelFor(Component)` and added keyboard navigation using `setDisplayedMnemonic('X')`.

---
*PR created automatically by Jules for task [16843157734631784884](https://jules.google.com/task/16843157734631784884) started by @yisshengyouni*