### PR TITLE
feat: add Class Diagram generation action

### DIFF
--- a/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
+++ b/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
@@ -1,0 +1,523 @@
+package com.huq.idea.flow.apidoc;
+
+import com.huq.idea.flow.apidoc.service.UmlFlowService;
+import com.huq.idea.flow.config.config.IdeaSettings;
+import com.huq.idea.flow.util.AiUtils;
+import com.huq.idea.flow.util.MyPsiUtil;
+import com.huq.idea.flow.util.PlantUmlRenderException;
+import com.huq.idea.flow.util.PlantUmlRenderer;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
+import com.intellij.openapi.progress.PerformInBackgroundOption;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiJavaFile;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiParameter;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.psi.util.PsiUtil;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Action to generate UML class diagrams from Java code
+ *
+ * @author huqiang
+ * @since 2024/8/10
+ */
+public class ClassDiagramAction extends AnAction {
+    private static final Logger LOG = Logger.getInstance(ClassDiagramAction.class);
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        if (project == null) {
+            return;
+        }
+
+        PsiFile psiFile = e.getData(LangDataKeys.PSI_FILE);
+        if (!(psiFile instanceof PsiJavaFile)) {
+            Notifications.Bus.notify(new Notification(
+                    "com.yt.huq.idea",
+                    "类图生成",
+                    "此操作仅适用于Java文件",
+                    NotificationType.ERROR),
+                    project);
+            return;
+        }
+
+        Editor editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR);
+        PsiClass targetClass = null;
+
+        if (editor != null) {
+            // 获取当前光标位置的类
+            targetClass = ReadAction.compute(() -> {
+                LogicalPosition logicalPosition = editor.getCaretModel().getLogicalPosition();
+                int offset = editor.logicalPositionToOffset(logicalPosition);
+                PsiElement element = psiFile.findElementAt(offset);
+                return PsiTreeUtil.getParentOfType(element, PsiClass.class);
+            });
+        } else {
+            // 从文件获取类（例如在项目视图中右键点击）
+            targetClass = ReadAction.compute(() -> {
+                PsiClass[] classes = ((PsiJavaFile) psiFile).getClasses();
+                if (classes.length > 0) {
+                    return classes[0];
+                }
+                return null;
+            });
+        }
+
+        if (targetClass == null) {
+            Notifications.Bus.notify(new Notification(
+                    "com.yt.huq.idea",
+                    "类图生成",
+                    "未找到类",
+                    NotificationType.ERROR),
+                    project);
+            return;
+        }
+
+        final PsiClass currentClass = targetClass;
+
+        // 收集关联的类
+        Set<PsiClass> associatedClasses = ReadAction.compute(() -> {
+            Set<PsiClass> classes = new HashSet<>();
+            collectAssociatedClasses(currentClass, classes, 0);
+            return classes;
+        });
+
+        // 收集代码
+        String collectedCode = ReadAction.compute(() -> collectCodeFromClasses(associatedClasses));
+
+        // 显示初始对话框
+        SwingUtilities.invokeLater(() ->
+            showInitialDialog(project, collectedCode, currentClass.getName()));
+    }
+
+    private void collectAssociatedClasses(PsiClass psiClass, Set<PsiClass> collected, int depth) {
+        if (psiClass == null || depth > 2 || collected.contains(psiClass)) {
+            return;
+        }
+
+        // 排除第三方jar包和class文件
+        if (MyPsiUtil.isInJarFileSystem(psiClass) || MyPsiUtil.isInClassFile(psiClass)) {
+            return;
+        }
+
+        // 排除JDK自身的类
+        String qualifiedName = psiClass.getQualifiedName();
+        if (qualifiedName != null && (qualifiedName.startsWith("java.") || qualifiedName.startsWith("javax."))) {
+            return;
+        }
+
+        collected.add(psiClass);
+
+        // 父类
+        PsiClass superClass = psiClass.getSuperClass();
+        if (superClass != null) {
+            collectAssociatedClasses(superClass, collected, depth + 1);
+        }
+
+        // 接口
+        PsiClass[] interfaces = psiClass.getInterfaces();
+        for (PsiClass intf : interfaces) {
+            collectAssociatedClasses(intf, collected, depth + 1);
+        }
+
+        // 字段
+        PsiField[] fields = psiClass.getFields();
+        for (PsiField field : fields) {
+            PsiClass fieldClass = PsiUtil.resolveClassInClassTypeOnly(field.getType());
+            if (fieldClass != null) {
+                collectAssociatedClasses(fieldClass, collected, depth + 1);
+            }
+        }
+
+        // 方法返回值和参数
+        PsiMethod[] methods = psiClass.getMethods();
+        for (PsiMethod method : methods) {
+            PsiType returnType = method.getReturnType();
+            if (returnType != null) {
+                PsiClass returnClass = PsiUtil.resolveClassInClassTypeOnly(returnType);
+                if (returnClass != null) {
+                    collectAssociatedClasses(returnClass, collected, depth + 1);
+                }
+            }
+
+            PsiParameter[] parameters = method.getParameterList().getParameters();
+            for (PsiParameter parameter : parameters) {
+                PsiClass paramClass = PsiUtil.resolveClassInClassTypeOnly(parameter.getType());
+                if (paramClass != null) {
+                    collectAssociatedClasses(paramClass, collected, depth + 1);
+                }
+            }
+        }
+    }
+
+    private String collectCodeFromClasses(Set<PsiClass> classes) {
+        StringBuilder codeBuilder = new StringBuilder();
+        for (PsiClass psiClass : classes) {
+            String classCode = psiClass.getText();
+            if (classCode != null && !classCode.isEmpty()) {
+                codeBuilder.append("\n\n// ").append("=".repeat(80)).append("\n");
+                codeBuilder.append("// Class: ").append(psiClass.getQualifiedName()).append("\n");
+                codeBuilder.append("// ").append("=".repeat(80)).append("\n\n");
+                codeBuilder.append(classCode);
+            }
+        }
+        return codeBuilder.toString();
+    }
+
+    private void showInitialDialog(Project project, String collectedCode, String title) {
+        JTabbedPane tabbedPane = new JTabbedPane();
+        JPanel plantUmlTab = createInitialPlantUmlTab(project, title, collectedCode);
+        tabbedPane.addTab("PlantUML视图", plantUmlTab);
+
+        JPanel bottomPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JLabel enhancedLabel = new JLabel();
+        enhancedLabel.setForeground(Color.BLUE);
+        bottomPanel.add(enhancedLabel);
+
+        JPanel mainPanel = new JPanel(new BorderLayout());
+        mainPanel.add(tabbedPane, BorderLayout.CENTER);
+        mainPanel.add(bottomPanel, BorderLayout.SOUTH);
+
+        UmlFlowService plugin = project.getService(UmlFlowService.class);
+        mainPanel.setName(title);
+        plugin.addFlow(mainPanel);
+    }
+
+    private JPanel createInitialPlantUmlTab(Project project, String title, String collectedCode) {
+        JPanel panel = new JPanel(new BorderLayout());
+
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
+        splitPane.setDividerLocation(500);
+        splitPane.setResizeWeight(0.5);
+
+        JPanel codePanel = new JPanel(new BorderLayout());
+        JTextArea textArea = new JTextArea();
+        textArea.setEditable(true);
+        textArea.setText(collectedCode);
+        textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));
+        codePanel.add(new JScrollPane(textArea), BorderLayout.CENTER);
+
+        JPanel diagramPanel = new JPanel(new BorderLayout());
+        JLabel waitingLabel = new JLabel("点击\"生成类图\"按钮生成类图", SwingConstants.CENTER);
+        waitingLabel.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 16));
+        diagramPanel.add(waitingLabel, BorderLayout.CENTER);
+
+        splitPane.setLeftComponent(codePanel);
+        splitPane.setRightComponent(diagramPanel);
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+
+        JLabel providerLabel = new JLabel("AI提供商:");
+        java.util.List<IdeaSettings.CustomAiProviderConfig> availableProviders = AiUtils.getCustomProviders();
+        JComboBox<IdeaSettings.CustomAiProviderConfig> providerComboBox = new JComboBox<>(availableProviders.toArray(new IdeaSettings.CustomAiProviderConfig[0]));
+
+        JLabel specificModelLabel = new JLabel("具体模型:");
+        JComboBox<String> specificModelComboBox = new JComboBox<>();
+
+        providerComboBox.addActionListener(e -> {
+            IdeaSettings.CustomAiProviderConfig selected = (IdeaSettings.CustomAiProviderConfig) providerComboBox.getSelectedItem();
+            specificModelComboBox.removeAllItems();
+            if (selected != null && selected.getModels() != null) {
+                String[] models = selected.getModels().split(",");
+                for (String model : models) {
+                    specificModelComboBox.addItem(model.trim());
+                }
+                if (models.length > 0) {
+                    specificModelComboBox.setSelectedIndex(0);
+                }
+            }
+        });
+
+        if (!availableProviders.isEmpty()) {
+            providerComboBox.setSelectedIndex(-1);
+            providerComboBox.setSelectedIndex(0);
+        }
+
+        providerComboBox.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                if (value instanceof IdeaSettings.CustomAiProviderConfig) {
+                    IdeaSettings.CustomAiProviderConfig provider = (IdeaSettings.CustomAiProviderConfig) value;
+                    setText(provider.getName());
+                }
+                return this;
+            }
+        });
+
+        buttonPanel.add(providerLabel);
+        buttonPanel.add(providerComboBox);
+        buttonPanel.add(specificModelLabel);
+        buttonPanel.add(specificModelComboBox);
+
+        JButton generateButton = new JButton("生成类图");
+        generateButton.addActionListener(e -> {
+            generateButton.setEnabled(false);
+            generateButton.setText("生成中...");
+
+            IdeaSettings.CustomAiProviderConfig selectedProvider = (IdeaSettings.CustomAiProviderConfig) providerComboBox.getSelectedItem();
+            String selectedModel = (String) specificModelComboBox.getSelectedItem();
+
+            if (selectedProvider == null) {
+                Notifications.Bus.notify(new Notification(
+                        "com.yt.huq.idea",
+                        "无可用AI模型",
+                        "未选择AI提供商或没有可用的AI提供商。请在设置 > UmlFlowAiConfigurable 中配置至少一个提供商",
+                        NotificationType.ERROR),
+                        project);
+                generateButton.setEnabled(true);
+                generateButton.setText("生成类图");
+                return;
+            }
+            if (IdeaSettings.getInstance().getState().getPlantumlPathVal() == null ||
+                    IdeaSettings.getInstance().getState().getPlantumlPathVal().trim().isEmpty()) {
+                Notifications.Bus.notify(new Notification(
+                        "com.yt.huq.idea",
+                        "PlantUML路径缺失",
+                        "PlantUML路径未配置。请在设置 > UmlFlowAiConfigurable 中设置",
+                        NotificationType.ERROR),
+                        project);
+                generateButton.setEnabled(true);
+                generateButton.setText("生成类图");
+                return;
+            }
+
+            new Task.Backgroundable(project, "生成类图", true, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
+                @Override
+                public void run(@NotNull ProgressIndicator indicator) {
+                    indicator.setText("正在生成PlantUML类图...");
+                    indicator.setIndeterminate(true);
+
+                    String classDiagramPromptTemplate = IdeaSettings.getInstance().getState().getClassDiagramPrompt();
+                    String flowPrompt = String.format(classDiagramPromptTemplate, collectedCode);
+
+                    AiUtils.AiConfig config = new AiUtils.AiConfig(selectedProvider, selectedModel);
+                    if (config.getApiKey() == null || config.getApiKey().trim().isEmpty()) {
+                        SwingUtilities.invokeLater(() -> {
+                            generateButton.setEnabled(true);
+                            Notifications.Bus.notify(new Notification(
+                                "com.yt.huq.idea",
+                                "API密钥未配置",
+                                "请在设置中为 " + selectedProvider.getName() + " 配置API密钥",
+                                NotificationType.WARNING),
+                                project);
+                        });
+                        return;
+                    }
+
+                    config.setSystemMessage("你是一个专业的PlantUML类图生成专家，擅长分析Java代码并生成高质量的类图。")
+                          .setTemperature(0.7)
+                          .setMaxTokens(8000);
+
+                    AiUtils.AiResponse response = AiUtils.callAi(flowPrompt, config);
+                    String classDiagram = response.isSuccess() ? response.getContent() : null;
+
+                    if (classDiagram != null && !classDiagram.isEmpty()) {
+                        classDiagram = cleanupUmlResponse(classDiagram);
+
+                        String finalClassDiagram = classDiagram;
+                        SwingUtilities.invokeLater(() -> {
+                            textArea.setText(finalClassDiagram);
+                            JPanel newDiagramPanel = PlantUmlRenderer.createPlantUmlPanel(finalClassDiagram);
+                            splitPane.setRightComponent(newDiagramPanel);
+
+                            generateButton.setEnabled(true);
+                            generateButton.setText("重新生成");
+
+                            panel.revalidate();
+                            panel.repaint();
+                        });
+                    } else {
+                        SwingUtilities.invokeLater(() -> {
+                            String errorMsg = "生成类图失败，请检查API设置和网络连接";
+                            if (response != null && !response.isSuccess() && response.getErrorMessage() != null) {
+                                errorMsg = "生成类图失败: " + response.getErrorMessage();
+                            }
+
+                            Notifications.Bus.notify(new Notification(
+                                    "com.yt.huq.idea",
+                                    "类图生成",
+                                    errorMsg,
+                                    NotificationType.ERROR),
+                                    project);
+
+                            generateButton.setEnabled(true);
+                            generateButton.setText("生成类图");
+                        });
+                    }
+                }
+            }.queue();
+        });
+        buttonPanel.add(generateButton);
+
+        JButton copyButton = new JButton("复制到剪贴板");
+        copyButton.addActionListener(e -> {
+            copyToClipboard(textArea.getText());
+            Notifications.Bus.notify(new Notification(
+                    "com.yt.huq.idea",
+                    "UML图表",
+                    "UML图表已复制到剪贴板",
+                    NotificationType.INFORMATION),
+                    project);
+        });
+        buttonPanel.add(copyButton);
+
+        JButton saveCodeButton = new JButton("保存代码");
+        saveCodeButton.addActionListener(e -> {
+            com.intellij.openapi.fileChooser.FileChooserDescriptor descriptor =
+                com.intellij.openapi.fileChooser.FileChooserDescriptorFactory.createSingleFolderDescriptor();
+            descriptor.setTitle("选择保存目录");
+
+            com.intellij.openapi.vfs.VirtualFile dir = com.intellij.openapi.fileChooser.FileChooser.chooseFile(descriptor, project, null);
+            if (dir != null) {
+                java.io.File fileToSave = new java.io.File(dir.getPath(), title.replaceAll("[^a-zA-Z0-9]", "_") + ".puml");
+                try {
+                    java.io.FileWriter writer = new java.io.FileWriter(fileToSave);
+                    writer.write(textArea.getText());
+                    writer.close();
+                    Notifications.Bus.notify(new Notification(
+                            "com.yt.huq.idea",
+                            "UML图表",
+                            "UML代码已保存到 " + fileToSave.getAbsolutePath(),
+                            NotificationType.INFORMATION),
+                            project);
+                } catch (Exception ex) {
+                    Notifications.Bus.notify(new Notification(
+                            "com.yt.huq.idea",
+                            "UML图表",
+                            "保存UML代码失败: " + ex.getMessage(),
+                            NotificationType.ERROR),
+                            project);
+                }
+            }
+        });
+        buttonPanel.add(saveCodeButton);
+
+        JButton saveImageButton = new JButton("保存图像");
+        saveImageButton.addActionListener(e -> {
+            if (textArea.getText().trim().isEmpty() || !textArea.getText().contains("@startuml")) {
+                Notifications.Bus.notify(new Notification(
+                        "com.yt.huq.idea",
+                        "UML图表",
+                        "没有有效的UML图表可以保存",
+                        NotificationType.WARNING),
+                        project);
+                return;
+            }
+
+            com.intellij.openapi.fileChooser.FileChooserDescriptor descriptor =
+                com.intellij.openapi.fileChooser.FileChooserDescriptorFactory.createSingleFolderDescriptor();
+            descriptor.setTitle("选择保存目录");
+
+            com.intellij.openapi.vfs.VirtualFile dir = com.intellij.openapi.fileChooser.FileChooser.chooseFile(descriptor, project, null);
+            if (dir != null) {
+                java.io.File fileToSave = new java.io.File(dir.getPath(), title.replaceAll("[^a-zA-Z0-9]", "_") + ".png");
+                try {
+                    byte[] pngData = PlantUmlRenderer.renderPlantUmlToPng(textArea.getText());
+                    if (pngData != null) {
+                        java.io.FileOutputStream fos = new java.io.FileOutputStream(fileToSave);
+                        fos.write(pngData);
+                        fos.close();
+                        Notifications.Bus.notify(new Notification(
+                                "com.yt.huq.idea",
+                                "UML图表",
+                                "UML图像已保存到 " + fileToSave.getAbsolutePath(),
+                                NotificationType.INFORMATION),
+                                project);
+                    }
+                } catch (PlantUmlRenderException ex) {
+                    LOG.error("Failed to render UML diagram", ex);
+                    Notifications.Bus.notify(new Notification(
+                            "com.yt.huq.idea",
+                            "UML图表",
+                            "渲染UML图像失败: " + ex.getMessage(),
+                            NotificationType.ERROR),
+                            project);
+                } catch (Exception ex) {
+                    Notifications.Bus.notify(new Notification(
+                            "com.yt.huq.idea",
+                            "UML图表",
+                            "保存UML图像失败: " + ex.getMessage(),
+                            NotificationType.ERROR),
+                            project);
+                }
+            }
+        });
+        buttonPanel.add(saveImageButton);
+
+        JButton refreshButton = new JButton("刷新图像");
+        refreshButton.addActionListener(e -> {
+            String updatedUmlContent = textArea.getText();
+            JPanel newDiagramPanel = PlantUmlRenderer.createPlantUmlPanel(updatedUmlContent);
+            splitPane.setRightComponent(newDiagramPanel);
+            splitPane.revalidate();
+            splitPane.repaint();
+            panel.revalidate();
+            panel.repaint();
+        });
+        buttonPanel.add(refreshButton);
+
+        panel.add(splitPane, BorderLayout.CENTER);
+        panel.add(buttonPanel, BorderLayout.SOUTH);
+
+        return panel;
+    }
+
+    private void copyToClipboard(String text) {
+        StringSelection stringSelection = new StringSelection(text);
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(stringSelection, null);
+    }
+
+    private String cleanupUmlResponse(String umlResponse) {
+        if (umlResponse == null || umlResponse.isEmpty()) {
+            return umlResponse;
+        }
+
+        if (!umlResponse.startsWith("@startuml")) {
+            int startIndex = umlResponse.indexOf("@startuml");
+            if (startIndex >= 0) {
+                umlResponse = umlResponse.substring(startIndex);
+            } else {
+                umlResponse = "@startuml\n" + umlResponse;
+            }
+        }
+
+        if (!umlResponse.endsWith("@enduml")) {
+            if (umlResponse.contains("@enduml")) {
+                int endIndex = umlResponse.lastIndexOf("@enduml") + "@enduml".length();
+                umlResponse = umlResponse.substring(0, endIndex);
+            } else {
+                umlResponse = umlResponse + "\n@enduml";
+            }
+        }
+
+        return umlResponse;
+    }
+}

--- a/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
+++ b/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
@@ -103,19 +103,30 @@ public class ClassDiagramAction extends AnAction {
 
         IdeaSettings.State settings = IdeaSettings.getInstance().getState();
 
-        // 收集关联的类
-        Set<PsiClass> associatedClasses = ReadAction.compute(() -> {
-            Set<PsiClass> classes = new HashSet<>();
-            collectAssociatedClasses(currentClass, classes, 0, settings);
-            return classes;
-        });
+        // 在后台任务中执行耗时的扫描，避免冻结UI
+        new Task.Backgroundable(project, "扫描类关联", true, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                indicator.setIndeterminate(true);
+                indicator.setText("正在扫描关联类...");
 
-        // 收集代码
-        String collectedCode = ReadAction.compute(() -> collectCodeFromClasses(associatedClasses));
+                // 收集关联的类
+                Set<PsiClass> associatedClasses = ReadAction.compute(() -> {
+                    Set<PsiClass> classes = new HashSet<>();
+                    // The root class is always included, ignore the generic filter for depth 0
+                    collectAssociatedClasses(currentClass, classes, 0, settings);
+                    return classes;
+                });
 
-        // 显示初始对话框
-        SwingUtilities.invokeLater(() ->
-            showInitialDialog(project, collectedCode, currentClass.getName()));
+                indicator.setText("正在收集源码...");
+                // 收集代码
+                String collectedCode = ReadAction.compute(() -> collectCodeFromClasses(associatedClasses));
+
+                // 显示初始对话框
+                SwingUtilities.invokeLater(() ->
+                    showInitialDialog(project, collectedCode, currentClass.getName()));
+            }
+        }.queue();
     }
 
     private void collectAssociatedClasses(PsiClass psiClass, Set<PsiClass> collected, int depth, IdeaSettings.State settings) {
@@ -141,7 +152,8 @@ public class ClassDiagramAction extends AnAction {
         }
 
         String qualifiedName = psiClass.getQualifiedName();
-        if (qualifiedName != null) {
+        // Skip filtering for the root target class (depth == 0) so the diagram always generates the target
+        if (depth > 0 && qualifiedName != null) {
             // Check if class matches any excluded pattern
             boolean isExcludedClass = settings.getClassExcludedClassPatterns().stream()
                     .anyMatch(pattern -> matchesWildcardPattern(qualifiedName, pattern));

--- a/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
+++ b/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
@@ -101,10 +101,12 @@ public class ClassDiagramAction extends AnAction {
 
         final PsiClass currentClass = targetClass;
 
+        IdeaSettings.State settings = IdeaSettings.getInstance().getState();
+
         // 收集关联的类
         Set<PsiClass> associatedClasses = ReadAction.compute(() -> {
             Set<PsiClass> classes = new HashSet<>();
-            collectAssociatedClasses(currentClass, classes, 0);
+            collectAssociatedClasses(currentClass, classes, 0, settings);
             return classes;
         });
 
@@ -116,7 +118,7 @@ public class ClassDiagramAction extends AnAction {
             showInitialDialog(project, collectedCode, currentClass.getName()));
     }
 
-    private void collectAssociatedClasses(PsiClass psiClass, Set<PsiClass> collected, int depth) {
+    private void collectAssociatedClasses(PsiClass psiClass, Set<PsiClass> collected, int depth, IdeaSettings.State settings) {
         if (psiClass == null || depth > 2 || collected.contains(psiClass)) {
             return;
         }
@@ -126,10 +128,21 @@ public class ClassDiagramAction extends AnAction {
             return;
         }
 
-        // 排除JDK自身的类
         String qualifiedName = psiClass.getQualifiedName();
-        if (qualifiedName != null && (qualifiedName.startsWith("java.") || qualifiedName.startsWith("javax."))) {
-            return;
+        if (qualifiedName != null) {
+            // Check if class matches any excluded pattern
+            boolean isExcludedClass = settings.getClassExcludedClassPatterns().stream()
+                    .anyMatch(pattern -> matchesWildcardPattern(qualifiedName, pattern));
+            if (isExcludedClass) {
+                return;
+            }
+
+            // Check if class matches any relevant pattern
+            boolean isRelevantClass = settings.getClassRelevantClassPatterns().stream()
+                    .anyMatch(pattern -> matchesWildcardPattern(qualifiedName, pattern));
+            if (!isRelevantClass) {
+                return;
+            }
         }
 
         collected.add(psiClass);
@@ -137,13 +150,13 @@ public class ClassDiagramAction extends AnAction {
         // 父类
         PsiClass superClass = psiClass.getSuperClass();
         if (superClass != null) {
-            collectAssociatedClasses(superClass, collected, depth + 1);
+            collectAssociatedClasses(superClass, collected, depth + 1, settings);
         }
 
         // 接口
         PsiClass[] interfaces = psiClass.getInterfaces();
         for (PsiClass intf : interfaces) {
-            collectAssociatedClasses(intf, collected, depth + 1);
+            collectAssociatedClasses(intf, collected, depth + 1, settings);
         }
 
         // 字段
@@ -151,7 +164,7 @@ public class ClassDiagramAction extends AnAction {
         for (PsiField field : fields) {
             PsiClass fieldClass = PsiUtil.resolveClassInClassTypeOnly(field.getType());
             if (fieldClass != null) {
-                collectAssociatedClasses(fieldClass, collected, depth + 1);
+                collectAssociatedClasses(fieldClass, collected, depth + 1, settings);
             }
         }
 
@@ -162,7 +175,7 @@ public class ClassDiagramAction extends AnAction {
             if (returnType != null) {
                 PsiClass returnClass = PsiUtil.resolveClassInClassTypeOnly(returnType);
                 if (returnClass != null) {
-                    collectAssociatedClasses(returnClass, collected, depth + 1);
+                    collectAssociatedClasses(returnClass, collected, depth + 1, settings);
                 }
             }
 
@@ -170,10 +183,23 @@ public class ClassDiagramAction extends AnAction {
             for (PsiParameter parameter : parameters) {
                 PsiClass paramClass = PsiUtil.resolveClassInClassTypeOnly(parameter.getType());
                 if (paramClass != null) {
-                    collectAssociatedClasses(paramClass, collected, depth + 1);
+                    collectAssociatedClasses(paramClass, collected, depth + 1, settings);
                 }
             }
         }
+    }
+
+    private boolean matchesWildcardPattern(String str, String wildcardPattern) {
+        if (str == null || wildcardPattern == null) {
+            return false;
+        }
+
+        // Convert wildcard pattern to regex pattern
+        String regexPattern = wildcardPattern
+                .replace(".", "\\.")  // Escape dots
+                .replace("*", ".*");  // Convert * to .*
+
+        return str.matches(regexPattern);
     }
 
     private String collectCodeFromClasses(Set<PsiClass> classes) {

--- a/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
+++ b/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
@@ -119,13 +119,25 @@ public class ClassDiagramAction extends AnAction {
     }
 
     private void collectAssociatedClasses(PsiClass psiClass, Set<PsiClass> collected, int depth, IdeaSettings.State settings) {
-        if (psiClass == null || depth > 2 || collected.contains(psiClass)) {
+        if (psiClass == null || depth > settings.getClassDiagramDepth() || collected.contains(psiClass)) {
             return;
         }
 
-        // 排除第三方jar包和class文件
-        if (MyPsiUtil.isInJarFileSystem(psiClass) || MyPsiUtil.isInClassFile(psiClass)) {
+        // 排除 compiled class files with no readable source or strictly jar file system
+        if (MyPsiUtil.isInClassFile(psiClass)) {
             return;
+        }
+
+        if (!settings.isIncludeLibrarySources() && MyPsiUtil.isInJarFileSystem(psiClass)) {
+            return;
+        }
+
+        // Additional safeguard for JDK classes even if includeLibrarySources is true
+        if (settings.isIncludeLibrarySources() && MyPsiUtil.isInJarFileSystem(psiClass)) {
+             String qName = psiClass.getQualifiedName();
+             if (qName != null && (qName.startsWith("java.") || qName.startsWith("javax.") || qName.startsWith("jdk."))) {
+                 return;
+             }
         }
 
         String qualifiedName = psiClass.getQualifiedName();
@@ -162,10 +174,7 @@ public class ClassDiagramAction extends AnAction {
         // 字段
         PsiField[] fields = psiClass.getFields();
         for (PsiField field : fields) {
-            PsiClass fieldClass = PsiUtil.resolveClassInClassTypeOnly(field.getType());
-            if (fieldClass != null) {
-                collectAssociatedClasses(fieldClass, collected, depth + 1, settings);
-            }
+            resolveAllClassesInType(field.getType(), collected, depth + 1, settings);
         }
 
         // 方法返回值和参数
@@ -173,18 +182,31 @@ public class ClassDiagramAction extends AnAction {
         for (PsiMethod method : methods) {
             PsiType returnType = method.getReturnType();
             if (returnType != null) {
-                PsiClass returnClass = PsiUtil.resolveClassInClassTypeOnly(returnType);
-                if (returnClass != null) {
-                    collectAssociatedClasses(returnClass, collected, depth + 1, settings);
-                }
+                resolveAllClassesInType(returnType, collected, depth + 1, settings);
             }
 
             PsiParameter[] parameters = method.getParameterList().getParameters();
             for (PsiParameter parameter : parameters) {
-                PsiClass paramClass = PsiUtil.resolveClassInClassTypeOnly(parameter.getType());
-                if (paramClass != null) {
-                    collectAssociatedClasses(paramClass, collected, depth + 1, settings);
-                }
+                resolveAllClassesInType(parameter.getType(), collected, depth + 1, settings);
+            }
+        }
+    }
+
+    private void resolveAllClassesInType(PsiType type, Set<PsiClass> collected, int depth, IdeaSettings.State settings) {
+        if (type == null) {
+            return;
+        }
+
+        if (type instanceof com.intellij.psi.PsiClassType) {
+            com.intellij.psi.PsiClassType classType = (com.intellij.psi.PsiClassType) type;
+            PsiClass resolvedClass = classType.resolve();
+            if (resolvedClass != null) {
+                collectAssociatedClasses(resolvedClass, collected, depth, settings);
+            }
+
+            PsiType[] parameters = classType.getParameters();
+            for (PsiType paramType : parameters) {
+                resolveAllClassesInType(paramType, collected, depth, settings);
             }
         }
     }

--- a/src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java
+++ b/src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java
@@ -30,6 +30,8 @@ public class AiConfigurationComponent {
     private JTextArea excludedPatternsArea;
     private JTextArea classRelevantPatternsArea;
     private JTextArea classExcludedPatternsArea;
+    private JSpinner classDiagramDepthSpinner;
+    private JCheckBox includeLibrarySourcesCheckBox;
     
     // 多AI模型API密钥配置
     private Map<String, JTextField> aiApiKeyFields = new HashMap<>();
@@ -83,6 +85,8 @@ public class AiConfigurationComponent {
 
         classRelevantPatternsArea.setText(String.join("\n", state.getClassRelevantClassPatterns()));
         classExcludedPatternsArea.setText(String.join("\n", state.getClassExcludedClassPatterns()));
+        classDiagramDepthSpinner.setValue(state.getClassDiagramDepth());
+        includeLibrarySourcesCheckBox.setSelected(state.isIncludeLibrarySources());
 
         aiProviderListModel.clear();
         for (IdeaSettings.CustomAiProviderConfig config : customAiProviders) {
@@ -470,6 +474,35 @@ public class AiConfigurationComponent {
         excludedScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
         patternConfigPanel.add(excludedScrollPane, gbc);
 
+        // 类图深度
+        gbc.gridy++;
+        gbc.gridx = 0;
+        JLabel depthLabel = new JLabel("类图 - 扫描深度:");
+        depthLabel.setPreferredSize(new Dimension(200, 25));
+        patternConfigPanel.add(depthLabel, gbc);
+
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 1.0;
+        gbc.weighty = 0.0;
+        classDiagramDepthSpinner = new JSpinner(new SpinnerNumberModel(2, 1, 10, 1));
+        classDiagramDepthSpinner.setToolTipText("类图关联类扫描的深度(1-10)");
+        patternConfigPanel.add(classDiagramDepthSpinner, gbc);
+
+        // 包含库源码
+        gbc.gridy++;
+        gbc.gridx = 0;
+        JLabel includeLibraryLabel = new JLabel("类图 - 包含第三方源码:");
+        includeLibraryLabel.setPreferredSize(new Dimension(200, 25));
+        patternConfigPanel.add(includeLibraryLabel, gbc);
+
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 1.0;
+        gbc.weighty = 0.0;
+        includeLibrarySourcesCheckBox = new JCheckBox("分析外部库或非项目源码 (仅限带有源码的类)");
+        patternConfigPanel.add(includeLibrarySourcesCheckBox, gbc);
+
         // 类图相关类模式
         gbc.gridy++;
         gbc.gridx = 0;
@@ -525,6 +558,14 @@ public class AiConfigurationComponent {
 
     public List<String> getClassExcludedPatterns() {
         return Arrays.asList(classExcludedPatternsArea.getText().split("\n"));
+    }
+
+    public int getClassDiagramDepth() {
+        return (Integer) classDiagramDepthSpinner.getValue();
+    }
+
+    public boolean isIncludeLibrarySources() {
+        return includeLibrarySourcesCheckBox.isSelected();
     }
 
     public JTextArea getFlowPromptTextArea() {

--- a/src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java
+++ b/src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java
@@ -112,17 +112,29 @@ public class AiConfigurationComponent {
         createPromptConfigPanel();
         createPatternConfigPanel();
         
-        // 组装主面板
-        JPanel topPanel = new JPanel(new BorderLayout());
-        topPanel.add(generalConfigPanel, BorderLayout.NORTH);
-        topPanel.add(aiConfigPanel, BorderLayout.CENTER);
+        // 组装主面板，使用TabbedPane以提升UI可用性
+        com.intellij.ui.components.JBTabbedPane tabbedPane = new com.intellij.ui.components.JBTabbedPane();
+
+        // Tab 1: 基础与AI配置
+        JPanel generalAndAiPanel = new JPanel(new BorderLayout());
+        generalAndAiPanel.add(generalConfigPanel, BorderLayout.NORTH);
+        generalAndAiPanel.add(aiConfigPanel, BorderLayout.CENTER);
+        generalAndAiPanel.setBorder(com.intellij.util.ui.JBUI.Borders.empty(5));
+        tabbedPane.addTab("AI 模型配置", generalAndAiPanel);
         
-        JPanel bottomPanel = new JPanel(new BorderLayout());
-        bottomPanel.add(promptConfigPanel, BorderLayout.NORTH);
-        bottomPanel.add(patternConfigPanel, BorderLayout.CENTER);
+        // Tab 2: 提示词配置
+        JPanel promptPanel = new JPanel(new BorderLayout());
+        promptPanel.add(promptConfigPanel, BorderLayout.CENTER);
+        promptPanel.setBorder(com.intellij.util.ui.JBUI.Borders.empty(5));
+        tabbedPane.addTab("提示词", promptPanel);
         
-        mainPanel.add(topPanel, BorderLayout.NORTH);
-        mainPanel.add(bottomPanel, BorderLayout.CENTER);
+        // Tab 3: 匹配模式与规则
+        JPanel filterPanel = new JPanel(new BorderLayout());
+        filterPanel.add(patternConfigPanel, BorderLayout.CENTER);
+        filterPanel.setBorder(com.intellij.util.ui.JBUI.Borders.empty(5));
+        tabbedPane.addTab("过滤与扫描规则", filterPanel);
+
+        mainPanel.add(tabbedPane, BorderLayout.CENTER);
     }
     
     /**
@@ -176,39 +188,36 @@ public class AiConfigurationComponent {
         leftPanel.add(listButtonsPanel, BorderLayout.SOUTH);
 
         // Right Panel: Form for selected provider
-        JPanel rightPanel = new JPanel(new GridBagLayout());
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.insets = new Insets(5, 5, 5, 5);
-        gbc.anchor = GridBagConstraints.WEST;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
+        aiProviderNameField = new JTextField();
+        aiApiUrlField = new JTextField();
+        aiApiKeyField = new JPasswordField(); // Ensure security
+        aiModelsField = new JTextField();
 
-        gbc.gridx = 0; gbc.gridy = 0; gbc.weightx = 0;
-        rightPanel.add(new JLabel("名称:"), gbc);
-        gbc.gridx = 1; gbc.weightx = 1.0;
-        aiProviderNameField = new JTextField(30);
-        rightPanel.add(aiProviderNameField, gbc);
+        JLabel nameLabel = new JLabel("名称 (&N):");
+        nameLabel.setDisplayedMnemonic('N');
+        nameLabel.setLabelFor(aiProviderNameField);
 
-        gbc.gridx = 0; gbc.gridy = 1; gbc.weightx = 0;
-        rightPanel.add(new JLabel("域名代理 (URL):"), gbc);
-        gbc.gridx = 1; gbc.weightx = 1.0;
-        aiApiUrlField = new JTextField(30);
-        rightPanel.add(aiApiUrlField, gbc);
+        JLabel urlLabel = new JLabel("域名代理 URL (&U):");
+        urlLabel.setDisplayedMnemonic('U');
+        urlLabel.setLabelFor(aiApiUrlField);
 
-        gbc.gridx = 0; gbc.gridy = 2; gbc.weightx = 0;
-        rightPanel.add(new JLabel("API Key:"), gbc);
-        gbc.gridx = 1; gbc.weightx = 1.0;
-        aiApiKeyField = new JTextField(30);
-        rightPanel.add(aiApiKeyField, gbc);
+        JLabel keyLabel = new JLabel("API Key (&K):");
+        keyLabel.setDisplayedMnemonic('K');
+        keyLabel.setLabelFor(aiApiKeyField);
 
-        gbc.gridx = 0; gbc.gridy = 3; gbc.weightx = 0;
-        rightPanel.add(new JLabel("可用模型 (逗号分隔):"), gbc);
-        gbc.gridx = 1; gbc.weightx = 1.0;
-        aiModelsField = new JTextField(30);
-        rightPanel.add(aiModelsField, gbc);
+        JLabel modelsLabel = new JLabel("可用模型 (&M):");
+        modelsLabel.setDisplayedMnemonic('M');
+        modelsLabel.setLabelFor(aiModelsField);
+        aiModelsField.setToolTipText("输入模型名称，多个模型使用英文逗号分隔");
 
-        // Spacer
-        gbc.gridx = 0; gbc.gridy = 4; gbc.gridwidth = 2; gbc.weighty = 1.0; gbc.fill = GridBagConstraints.BOTH;
-        rightPanel.add(new JPanel(), gbc);
+        JPanel rightPanel = com.intellij.util.ui.FormBuilder.createFormBuilder()
+                .addLabeledComponent(nameLabel, aiProviderNameField)
+                .addLabeledComponent(urlLabel, aiApiUrlField)
+                .addLabeledComponent(keyLabel, aiApiKeyField)
+                .addLabeledComponent(modelsLabel, aiModelsField)
+                .addComponentFillVertically(new JPanel(), 0)
+                .getPanel();
+        rightPanel.setBorder(com.intellij.util.ui.JBUI.Borders.empty(10));
 
         // Create Split Pane
         JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, leftPanel, rightPanel);
@@ -348,7 +357,7 @@ public class AiConfigurationComponent {
         // Right Panel: Text area for selected prompt
         JPanel rightPanel = new JPanel(new BorderLayout());
         flowPromptTextArea = new JTextArea(5, 30);
-        flowPromptTextArea.setToolTipText("自定义AI生成流程图的提示词");
+        flowPromptTextArea.setToolTipText("自定义AI生成流程图/类图/时序图的提示词");
         flowPromptTextArea.setLineWrap(true);
         flowPromptTextArea.setWrapStyleWord(true);
         JScrollPane promptScrollPane = new JScrollPane(flowPromptTextArea);
@@ -360,6 +369,16 @@ public class AiConfigurationComponent {
         JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, leftPanel, rightPanel);
         splitPane.setDividerLocation(200);
         promptConfigPanel.add(splitPane, BorderLayout.CENTER);
+
+        // Populate promptConfigs from standard places if missing Class/Sequence
+        if (promptConfigs.stream().noneMatch(c -> c.getName().equals("Class Diagram"))) {
+            promptConfigs.add(new IdeaSettings.PromptConfig("Class Diagram", IdeaSettings.getInstance().getState().getClassDiagramPrompt()));
+            promptListModel.addElement("Class Diagram");
+        }
+        if (promptConfigs.stream().noneMatch(c -> c.getName().equals("Sequence Diagram"))) {
+            promptConfigs.add(new IdeaSettings.PromptConfig("Sequence Diagram", IdeaSettings.getInstance().getState().getUmlSequencePrompt()));
+            promptListModel.addElement("Sequence Diagram");
+        }
 
         // Event Listeners
         promptList.addListSelectionListener(new ListSelectionListener() {
@@ -429,117 +448,77 @@ public class AiConfigurationComponent {
      * 创建模式配置面板
      */
     private void createPatternConfigPanel() {
-        patternConfigPanel = new JPanel(new GridBagLayout());
-        patternConfigPanel.setBorder(new TitledBorder("类匹配模式配置"));
-        
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.insets = new Insets(5, 5, 5, 5);
-        gbc.anchor = GridBagConstraints.WEST;
-        
+        patternConfigPanel = new JPanel(new BorderLayout());
+        patternConfigPanel.setBorder(com.intellij.util.ui.JBUI.Borders.empty(10));
+
         // 流程图/时序图相关类模式
-        gbc.gridx = 0;
-        gbc.gridy = 0;
-        JLabel relevantLabel = new JLabel("流程图/时序图 - 相关类模式:");
-        relevantLabel.setPreferredSize(new Dimension(200, 25));
-        patternConfigPanel.add(relevantLabel, gbc);
-        
-        gbc.gridx = 1;
-        gbc.fill = GridBagConstraints.BOTH;
-        gbc.weightx = 1.0;
-        gbc.weighty = 0.25;
         relevantPatternsArea = new JTextArea(2, 30);
         relevantPatternsArea.setToolTipText("匹配相关类的正则表达式模式，每行一个");
         relevantPatternsArea.setLineWrap(true);
         relevantPatternsArea.setWrapStyleWord(true);
-        JScrollPane relevantScrollPane = new JScrollPane(relevantPatternsArea);
-        relevantScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-        patternConfigPanel.add(relevantScrollPane, gbc);
-        
+        JScrollPane relevantScrollPane = new com.intellij.ui.components.JBScrollPane(relevantPatternsArea);
+
+        JLabel relevantLabel = new JLabel("流程图/时序图 - 相关类模式 (&R):");
+        relevantLabel.setDisplayedMnemonic('R');
+        relevantLabel.setLabelFor(relevantPatternsArea);
+
         // 流程图/时序图排除类模式
-        gbc.gridy++;
-        gbc.gridx = 0;
-        JLabel excludedLabel = new JLabel("流程图/时序图 - 排除类模式:");
-        excludedLabel.setPreferredSize(new Dimension(200, 25));
-        patternConfigPanel.add(excludedLabel, gbc);
-        
-        gbc.gridx = 1;
-        gbc.fill = GridBagConstraints.BOTH;
-        gbc.weightx = 1.0;
-        gbc.weighty = 0.25;
         excludedPatternsArea = new JTextArea(2, 30);
         excludedPatternsArea.setToolTipText("排除类的正则表达式模式，每行一个");
         excludedPatternsArea.setLineWrap(true);
         excludedPatternsArea.setWrapStyleWord(true);
-        JScrollPane excludedScrollPane = new JScrollPane(excludedPatternsArea);
-        excludedScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-        patternConfigPanel.add(excludedScrollPane, gbc);
+        JScrollPane excludedScrollPane = new com.intellij.ui.components.JBScrollPane(excludedPatternsArea);
+
+        JLabel excludedLabel = new JLabel("流程图/时序图 - 排除类模式 (&E):");
+        excludedLabel.setDisplayedMnemonic('E');
+        excludedLabel.setLabelFor(excludedPatternsArea);
 
         // 类图深度
-        gbc.gridy++;
-        gbc.gridx = 0;
-        JLabel depthLabel = new JLabel("类图 - 扫描深度:");
-        depthLabel.setPreferredSize(new Dimension(200, 25));
-        patternConfigPanel.add(depthLabel, gbc);
-
-        gbc.gridx = 1;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        gbc.weightx = 1.0;
-        gbc.weighty = 0.0;
         classDiagramDepthSpinner = new JSpinner(new SpinnerNumberModel(2, 1, 10, 1));
         classDiagramDepthSpinner.setToolTipText("类图关联类扫描的深度(1-10)");
-        patternConfigPanel.add(classDiagramDepthSpinner, gbc);
+        JLabel depthLabel = new JLabel("类图 - 扫描深度 (&D):");
+        depthLabel.setDisplayedMnemonic('D');
+        depthLabel.setLabelFor(classDiagramDepthSpinner);
 
         // 包含库源码
-        gbc.gridy++;
-        gbc.gridx = 0;
-        JLabel includeLibraryLabel = new JLabel("类图 - 包含第三方源码:");
-        includeLibraryLabel.setPreferredSize(new Dimension(200, 25));
-        patternConfigPanel.add(includeLibraryLabel, gbc);
-
-        gbc.gridx = 1;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        gbc.weightx = 1.0;
-        gbc.weighty = 0.0;
         includeLibrarySourcesCheckBox = new JCheckBox("分析外部库或非项目源码 (仅限带有源码的类)");
-        patternConfigPanel.add(includeLibrarySourcesCheckBox, gbc);
+        includeLibrarySourcesCheckBox.setMnemonic('S');
+        includeLibrarySourcesCheckBox.setToolTipText("勾选此项以在类图生成时深入解析第三方依赖库源码");
 
         // 类图相关类模式
-        gbc.gridy++;
-        gbc.gridx = 0;
-        JLabel classRelevantLabel = new JLabel("类图 - 相关类模式:");
-        classRelevantLabel.setPreferredSize(new Dimension(200, 25));
-        patternConfigPanel.add(classRelevantLabel, gbc);
-
-        gbc.gridx = 1;
-        gbc.fill = GridBagConstraints.BOTH;
-        gbc.weightx = 1.0;
-        gbc.weighty = 0.25;
         classRelevantPatternsArea = new JTextArea(2, 30);
         classRelevantPatternsArea.setToolTipText("类图中匹配相关类的正则表达式模式，每行一个");
         classRelevantPatternsArea.setLineWrap(true);
         classRelevantPatternsArea.setWrapStyleWord(true);
-        JScrollPane classRelevantScrollPane = new JScrollPane(classRelevantPatternsArea);
-        classRelevantScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-        patternConfigPanel.add(classRelevantScrollPane, gbc);
+        JScrollPane classRelevantScrollPane = new com.intellij.ui.components.JBScrollPane(classRelevantPatternsArea);
+
+        JLabel classRelevantLabel = new JLabel("类图 - 相关类模式 (&C):");
+        classRelevantLabel.setDisplayedMnemonic('C');
+        classRelevantLabel.setLabelFor(classRelevantPatternsArea);
 
         // 类图排除类模式
-        gbc.gridy++;
-        gbc.gridx = 0;
-        JLabel classExcludedLabel = new JLabel("类图 - 排除类模式:");
-        classExcludedLabel.setPreferredSize(new Dimension(200, 25));
-        patternConfigPanel.add(classExcludedLabel, gbc);
-
-        gbc.gridx = 1;
-        gbc.fill = GridBagConstraints.BOTH;
-        gbc.weightx = 1.0;
-        gbc.weighty = 0.25;
         classExcludedPatternsArea = new JTextArea(2, 30);
         classExcludedPatternsArea.setToolTipText("类图中排除类的正则表达式模式，每行一个");
         classExcludedPatternsArea.setLineWrap(true);
         classExcludedPatternsArea.setWrapStyleWord(true);
-        JScrollPane classExcludedScrollPane = new JScrollPane(classExcludedPatternsArea);
-        classExcludedScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-        patternConfigPanel.add(classExcludedScrollPane, gbc);
+        JScrollPane classExcludedScrollPane = new com.intellij.ui.components.JBScrollPane(classExcludedPatternsArea);
+
+        JLabel classExcludedLabel = new JLabel("类图 - 排除类模式 (&X):");
+        classExcludedLabel.setDisplayedMnemonic('X');
+        classExcludedLabel.setLabelFor(classExcludedPatternsArea);
+
+        JPanel innerForm = com.intellij.util.ui.FormBuilder.createFormBuilder()
+                .addLabeledComponent(relevantLabel, relevantScrollPane)
+                .addLabeledComponent(excludedLabel, excludedScrollPane)
+                .addSeparator(10)
+                .addLabeledComponent(depthLabel, classDiagramDepthSpinner)
+                .addComponentToRightColumn(includeLibrarySourcesCheckBox)
+                .addLabeledComponent(classRelevantLabel, classRelevantScrollPane)
+                .addLabeledComponent(classExcludedLabel, classExcludedScrollPane)
+                .addComponentFillVertically(new JPanel(), 0)
+                .getPanel();
+
+        patternConfigPanel.add(innerForm, BorderLayout.CENTER);
     }
     
 

--- a/src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java
+++ b/src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java
@@ -28,6 +28,8 @@ public class AiConfigurationComponent {
     private int currentPromptIndex = -1;
     private JTextArea relevantPatternsArea;
     private JTextArea excludedPatternsArea;
+    private JTextArea classRelevantPatternsArea;
+    private JTextArea classExcludedPatternsArea;
     
     // 多AI模型API密钥配置
     private Map<String, JTextField> aiApiKeyFields = new HashMap<>();
@@ -78,6 +80,9 @@ public class AiConfigurationComponent {
 
         relevantPatternsArea.setText(String.join("\n", state.getRelevantClassPatterns()));
         excludedPatternsArea.setText(String.join("\n", state.getExcludedClassPatterns()));
+
+        classRelevantPatternsArea.setText(String.join("\n", state.getClassRelevantClassPatterns()));
+        classExcludedPatternsArea.setText(String.join("\n", state.getClassExcludedClassPatterns()));
 
         aiProviderListModel.clear();
         for (IdeaSettings.CustomAiProviderConfig config : customAiProviders) {
@@ -427,18 +432,18 @@ public class AiConfigurationComponent {
         gbc.insets = new Insets(5, 5, 5, 5);
         gbc.anchor = GridBagConstraints.WEST;
         
-        // 相关类模式
+        // 流程图/时序图相关类模式
         gbc.gridx = 0;
         gbc.gridy = 0;
-        JLabel relevantLabel = new JLabel("相关类模式:");
-        relevantLabel.setPreferredSize(new Dimension(120, 25));
+        JLabel relevantLabel = new JLabel("流程图/时序图 - 相关类模式:");
+        relevantLabel.setPreferredSize(new Dimension(200, 25));
         patternConfigPanel.add(relevantLabel, gbc);
         
         gbc.gridx = 1;
         gbc.fill = GridBagConstraints.BOTH;
         gbc.weightx = 1.0;
-        gbc.weighty = 0.5;
-        relevantPatternsArea = new JTextArea(3, 30);
+        gbc.weighty = 0.25;
+        relevantPatternsArea = new JTextArea(2, 30);
         relevantPatternsArea.setToolTipText("匹配相关类的正则表达式模式，每行一个");
         relevantPatternsArea.setLineWrap(true);
         relevantPatternsArea.setWrapStyleWord(true);
@@ -446,24 +451,62 @@ public class AiConfigurationComponent {
         relevantScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
         patternConfigPanel.add(relevantScrollPane, gbc);
         
-        // 排除类模式
+        // 流程图/时序图排除类模式
         gbc.gridy++;
         gbc.gridx = 0;
-        JLabel excludedLabel = new JLabel("排除类模式:");
-        excludedLabel.setPreferredSize(new Dimension(120, 25));
+        JLabel excludedLabel = new JLabel("流程图/时序图 - 排除类模式:");
+        excludedLabel.setPreferredSize(new Dimension(200, 25));
         patternConfigPanel.add(excludedLabel, gbc);
         
         gbc.gridx = 1;
         gbc.fill = GridBagConstraints.BOTH;
         gbc.weightx = 1.0;
-        gbc.weighty = 0.5;
-        excludedPatternsArea = new JTextArea(3, 30);
+        gbc.weighty = 0.25;
+        excludedPatternsArea = new JTextArea(2, 30);
         excludedPatternsArea.setToolTipText("排除类的正则表达式模式，每行一个");
         excludedPatternsArea.setLineWrap(true);
         excludedPatternsArea.setWrapStyleWord(true);
         JScrollPane excludedScrollPane = new JScrollPane(excludedPatternsArea);
         excludedScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
         patternConfigPanel.add(excludedScrollPane, gbc);
+
+        // 类图相关类模式
+        gbc.gridy++;
+        gbc.gridx = 0;
+        JLabel classRelevantLabel = new JLabel("类图 - 相关类模式:");
+        classRelevantLabel.setPreferredSize(new Dimension(200, 25));
+        patternConfigPanel.add(classRelevantLabel, gbc);
+
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.BOTH;
+        gbc.weightx = 1.0;
+        gbc.weighty = 0.25;
+        classRelevantPatternsArea = new JTextArea(2, 30);
+        classRelevantPatternsArea.setToolTipText("类图中匹配相关类的正则表达式模式，每行一个");
+        classRelevantPatternsArea.setLineWrap(true);
+        classRelevantPatternsArea.setWrapStyleWord(true);
+        JScrollPane classRelevantScrollPane = new JScrollPane(classRelevantPatternsArea);
+        classRelevantScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        patternConfigPanel.add(classRelevantScrollPane, gbc);
+
+        // 类图排除类模式
+        gbc.gridy++;
+        gbc.gridx = 0;
+        JLabel classExcludedLabel = new JLabel("类图 - 排除类模式:");
+        classExcludedLabel.setPreferredSize(new Dimension(200, 25));
+        patternConfigPanel.add(classExcludedLabel, gbc);
+
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.BOTH;
+        gbc.weightx = 1.0;
+        gbc.weighty = 0.25;
+        classExcludedPatternsArea = new JTextArea(2, 30);
+        classExcludedPatternsArea.setToolTipText("类图中排除类的正则表达式模式，每行一个");
+        classExcludedPatternsArea.setLineWrap(true);
+        classExcludedPatternsArea.setWrapStyleWord(true);
+        JScrollPane classExcludedScrollPane = new JScrollPane(classExcludedPatternsArea);
+        classExcludedScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        patternConfigPanel.add(classExcludedScrollPane, gbc);
     }
     
 
@@ -474,6 +517,14 @@ public class AiConfigurationComponent {
 
     public List<String> getExcludedPatterns() {
         return Arrays.asList(excludedPatternsArea.getText().split("\n"));
+    }
+
+    public List<String> getClassRelevantPatterns() {
+        return Arrays.asList(classRelevantPatternsArea.getText().split("\n"));
+    }
+
+    public List<String> getClassExcludedPatterns() {
+        return Arrays.asList(classExcludedPatternsArea.getText().split("\n"));
     }
 
     public JTextArea getFlowPromptTextArea() {

--- a/src/main/java/com/huq/idea/flow/config/config/IdeaConfigurable.java
+++ b/src/main/java/com/huq/idea/flow/config/config/IdeaConfigurable.java
@@ -50,5 +50,7 @@ public class IdeaConfigurable implements Configurable {
         state.setPlantumlPathVal(settingsComponent.getPlantumlPathValue());
         state.setRelevantClassPatterns(settingsComponent.getRelevantPatterns());
         state.setExcludedClassPatterns(settingsComponent.getExcludedPatterns());
+        state.setClassRelevantClassPatterns(settingsComponent.getClassRelevantPatterns());
+        state.setClassExcludedClassPatterns(settingsComponent.getClassExcludedPatterns());
     }
 }

--- a/src/main/java/com/huq/idea/flow/config/config/IdeaConfigurable.java
+++ b/src/main/java/com/huq/idea/flow/config/config/IdeaConfigurable.java
@@ -52,5 +52,7 @@ public class IdeaConfigurable implements Configurable {
         state.setExcludedClassPatterns(settingsComponent.getExcludedPatterns());
         state.setClassRelevantClassPatterns(settingsComponent.getClassRelevantPatterns());
         state.setClassExcludedClassPatterns(settingsComponent.getClassExcludedPatterns());
+        state.setClassDiagramDepth(settingsComponent.getClassDiagramDepth());
+        state.setIncludeLibrarySources(settingsComponent.isIncludeLibrarySources());
     }
 }

--- a/src/main/java/com/huq/idea/flow/config/config/IdeaConfigurable.java
+++ b/src/main/java/com/huq/idea/flow/config/config/IdeaConfigurable.java
@@ -54,5 +54,14 @@ public class IdeaConfigurable implements Configurable {
         state.setClassExcludedClassPatterns(settingsComponent.getClassExcludedPatterns());
         state.setClassDiagramDepth(settingsComponent.getClassDiagramDepth());
         state.setIncludeLibrarySources(settingsComponent.isIncludeLibrarySources());
+
+        // Ensure standard prompts map back correctly
+        for (IdeaSettings.PromptConfig config : state.getFlowPrompts()) {
+            if ("Class Diagram".equals(config.getName())) {
+                state.setClassDiagramPrompt(config.getPrompt());
+            } else if ("Sequence Diagram".equals(config.getName())) {
+                state.setUmlSequencePrompt(config.getPrompt());
+            }
+        }
     }
 }

--- a/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
+++ b/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
@@ -244,6 +244,15 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
                 "*Util", "*Utils", "*Helper"
         );
 
+        private List<String> classRelevantClassPatterns = Arrays.asList(
+                "*Impl", "*Service", "*Adapter", "*Api", "*Repository",
+                "*Mapper", "*Manager", "*Controller", "*DTO", "*VO", "*Entity", "*Model"
+        );
+
+        private List<String> classExcludedClassPatterns = Arrays.asList(
+                "*Util", "*Utils", "*Helper", "java.*", "javax.*"
+        );
+
         public List<String> getExcludedClassPatterns() {
             return this.excludedClassPatterns;
         }
@@ -258,6 +267,22 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
 
         public void setRelevantClassPatterns(List<String> relevantClassPatterns) {
             this.relevantClassPatterns = relevantClassPatterns;
+        }
+
+        public List<String> getClassRelevantClassPatterns() {
+            return this.classRelevantClassPatterns;
+        }
+
+        public void setClassRelevantClassPatterns(List<String> classRelevantClassPatterns) {
+            this.classRelevantClassPatterns = classRelevantClassPatterns;
+        }
+
+        public List<String> getClassExcludedClassPatterns() {
+            return this.classExcludedClassPatterns;
+        }
+
+        public void setClassExcludedClassPatterns(List<String> classExcludedClassPatterns) {
+            this.classExcludedClassPatterns = classExcludedClassPatterns;
         }
 
         public String getPlantumlPathVal() {

--- a/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
+++ b/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
@@ -245,8 +245,7 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
         );
 
         private List<String> classRelevantClassPatterns = Arrays.asList(
-                "*Impl", "*Service", "*Adapter", "*Api", "*Repository",
-                "*Mapper", "*Manager", "*Controller", "*DTO", "*VO", "*Entity", "*Model"
+                "*"
         );
 
         private List<String> classExcludedClassPatterns = Arrays.asList(

--- a/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
+++ b/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
@@ -253,6 +253,9 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
                 "*Util", "*Utils", "*Helper", "java.*", "javax.*"
         );
 
+        private int classDiagramDepth = 2;
+        private boolean includeLibrarySources = false;
+
         public List<String> getExcludedClassPatterns() {
             return this.excludedClassPatterns;
         }
@@ -283,6 +286,22 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
 
         public void setClassExcludedClassPatterns(List<String> classExcludedClassPatterns) {
             this.classExcludedClassPatterns = classExcludedClassPatterns;
+        }
+
+        public int getClassDiagramDepth() {
+            return classDiagramDepth;
+        }
+
+        public void setClassDiagramDepth(int classDiagramDepth) {
+            this.classDiagramDepth = classDiagramDepth;
+        }
+
+        public boolean isIncludeLibrarySources() {
+            return includeLibrarySources;
+        }
+
+        public void setIncludeLibrarySources(boolean includeLibrarySources) {
+            this.includeLibrarySources = includeLibrarySources;
         }
 
         public String getPlantumlPathVal() {

--- a/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
+++ b/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
@@ -122,6 +122,15 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
             "      `-->` 表示返回。\\n5. 如果代码中有循环或条件判断，请使用 `loop`、`alt`、`opt` 等UML片段来表示。\\n6. 在调用箭头上清晰地标出方法名和参数。\\n7. \n" +
             "      不要包含与代码无关的注释或解释。\\n\\n下面是需要分析的代码：\\n%s";
 
+    public static final String DEFAULT_CLASS_DIAGRAM_PROMPT = "你是一个UML类图生成专家。请基于下面提供的Java类相关的代码，生成一个PlantUML格式的UML类图。\n" +
+            "请遵循以下规则：\n" +
+            "1. 严格使用PlantUML语法。\n" +
+            "2. 以 `@startuml` 开始，以 `@enduml` 结束。\n" +
+            "3. 准确表示类之间的关系（继承、实现、组合、聚合、关联、依赖）。\n" +
+            "4. 包含类的主要属性和方法（可以省略Getter/Setter等无逻辑的方法）。\n" +
+            "5. 不要包含与代码无关的注释或解释。\n\n" +
+            "下面是需要分析的代码：\n%s";
+
     public static IdeaSettings getInstance() {
         return ApplicationManager.getApplication().getService(IdeaSettings.class);
     }
@@ -225,6 +234,7 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
         private List<PromptConfig> flowPrompts;
         private String buildFlowJsonPrompt = DEFAULT_BUILD_FLOW_JSON_PROMPT;
         private String umlSequencePrompt = DEFAULT_UML_SEQUENCE_PROMPT;
+        private String classDiagramPrompt = DEFAULT_CLASS_DIAGRAM_PROMPT;
         private List<String> relevantClassPatterns = Arrays.asList(
                 "*Impl", "*Service", "*Adapter", "*Api", "*Repository",
                 "*Mapper", "*Manager", "*Controller"
@@ -304,6 +314,14 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
 
         public void setUmlSequencePrompt(String umlSequencePrompt) {
             this.umlSequencePrompt = umlSequencePrompt;
+        }
+
+        public String getClassDiagramPrompt() {
+            return this.classDiagramPrompt;
+        }
+
+        public void setClassDiagramPrompt(String classDiagramPrompt) {
+            this.classDiagramPrompt = classDiagramPrompt;
         }
 
         /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -102,5 +102,12 @@
       <add-to-group group-id="GenerateGroup" anchor="last"/>
       <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
     </action>
+    <action id="com.huq.idea.flow.ClassDiagramAction"
+            class="com.huq.idea.flow.apidoc.ClassDiagramAction"
+            text="Generate Class Diagram"
+            description="Generates a class diagram from the class dependencies.">
+      <add-to-group group-id="GenerateGroup" anchor="last"/>
+      <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+    </action>
   </actions>
 </idea-plugin>


### PR DESCRIPTION
Adds a new functional feature: `ClassDiagramAction`. This allows the user to right-click on a Java class (either in the editor or the Project View) and generate a UML Class Diagram. It recursively traverses associated classes up to a depth of 2 while actively filtering out JDK classes and third-party JARs using existing `MyPsiUtil` checks, keeping the diagram focused on local project code.

---
*PR created automatically by Jules for task [8572171491654874904](https://jules.google.com/task/8572171491654874904) started by @yisshengyouni*