### PR TITLE
feat: add SVG export and State Diagram generation

### DIFF
--- a/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
+++ b/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
@@ -531,6 +531,58 @@ public class ClassDiagramAction extends AnAction {
         });
         buttonPanel.add(saveImageButton);
 
+        JButton saveSvgButton = new JButton("保存SVG");
+        saveSvgButton.addActionListener(e -> {
+            if (textArea.getText().trim().isEmpty() || !textArea.getText().contains("@startuml")) {
+                Notifications.Bus.notify(new Notification(
+                        "com.yt.huq.idea",
+                        "UML图表",
+                        "没有有效的UML图表可以保存",
+                        NotificationType.WARNING),
+                        project);
+                return;
+            }
+
+            com.intellij.openapi.fileChooser.FileChooserDescriptor descriptor =
+                com.intellij.openapi.fileChooser.FileChooserDescriptorFactory.createSingleFolderDescriptor();
+            descriptor.setTitle("选择保存目录");
+
+            com.intellij.openapi.vfs.VirtualFile dir = com.intellij.openapi.fileChooser.FileChooser.chooseFile(descriptor, project, null);
+            if (dir != null) {
+                java.io.File fileToSave = new java.io.File(dir.getPath(), title.replaceAll("[^a-zA-Z0-9]", "_") + ".svg");
+                try {
+                    String svgData = PlantUmlRenderer.renderPlantUmlToSvg(textArea.getText());
+                    if (svgData != null) {
+                        java.io.FileWriter writer = new java.io.FileWriter(fileToSave);
+                        writer.write(svgData);
+                        writer.close();
+                        Notifications.Bus.notify(new Notification(
+                                "com.yt.huq.idea",
+                                "UML图表",
+                                "UML SVG已保存到 " + fileToSave.getAbsolutePath(),
+                                NotificationType.INFORMATION),
+                                project);
+                    }
+                } catch (PlantUmlRenderException ex) {
+                    LOG.error("Failed to render UML diagram to SVG", ex);
+                    Notifications.Bus.notify(new Notification(
+                            "com.yt.huq.idea",
+                            "UML图表",
+                            "渲染UML SVG失败: " + ex.getMessage(),
+                            NotificationType.ERROR),
+                            project);
+                } catch (Exception ex) {
+                    Notifications.Bus.notify(new Notification(
+                            "com.yt.huq.idea",
+                            "UML图表",
+                            "保存UML SVG失败: " + ex.getMessage(),
+                            NotificationType.ERROR),
+                            project);
+                }
+            }
+        });
+        buttonPanel.add(saveSvgButton);
+
         JButton refreshButton = new JButton("刷新图像");
         refreshButton.addActionListener(e -> {
             String updatedUmlContent = textArea.getText();

--- a/src/main/java/com/huq/idea/flow/apidoc/SequenceDiagramAction.java
+++ b/src/main/java/com/huq/idea/flow/apidoc/SequenceDiagramAction.java
@@ -439,6 +439,61 @@ public class SequenceDiagramAction extends AnAction implements DumbAware {
         });
         buttonPanel.add(saveImageButton);
 
+        // 保存SVG按钮
+        JButton saveSvgButton = new JButton("保存SVG");
+        saveSvgButton.addActionListener(e -> {
+            // 检查是否有内容可以保存
+            if (textArea.getText().trim().isEmpty() || !textArea.getText().contains("@startuml")) {
+                Notifications.Bus.notify(new Notification(
+                        "com.yt.huq.idea",
+                        "UML图表",
+                        "没有有效的UML图表可以保存",
+                        NotificationType.WARNING),
+                        project);
+                return;
+            }
+
+            JFileChooser fileChooser = new JFileChooser();
+            fileChooser.setDialogTitle("保存UML SVG");
+            fileChooser.setSelectedFile(new java.io.File(parentFrame.getTitle().replaceAll("[^a-zA-Z0-9]", "_") + ".svg"));
+
+            int userSelection = fileChooser.showSaveDialog(parentFrame);
+            if (userSelection == JFileChooser.APPROVE_OPTION) {
+                java.io.File fileToSave = fileChooser.getSelectedFile();
+                try {
+                    // 渲染并保存SVG
+                    String svgData = PlantUmlRenderer.renderPlantUmlToSvg(textArea.getText());
+                    if (svgData != null) {
+                        java.io.FileWriter writer = new java.io.FileWriter(fileToSave);
+                        writer.write(svgData);
+                        writer.close();
+                        Notifications.Bus.notify(new Notification(
+                                "com.yt.huq.idea",
+                                "UML图表",
+                                "UML SVG已保存到 " + fileToSave.getAbsolutePath(),
+                                NotificationType.INFORMATION),
+                                project);
+                    }
+                } catch (PlantUmlRenderException ex) {
+                    LOG.error("Failed to render UML diagram to SVG", ex);
+                    Notifications.Bus.notify(new Notification(
+                            "com.yt.huq.idea",
+                            "UML图表",
+                            "渲染UML SVG失败: " + ex.getMessage(),
+                            NotificationType.ERROR),
+                            project);
+                } catch (Exception ex) {
+                    Notifications.Bus.notify(new Notification(
+                            "com.yt.huq.idea",
+                            "UML图表",
+                            "保存UML SVG失败: " + ex.getMessage(),
+                            NotificationType.ERROR),
+                            project);
+                }
+            }
+        });
+        buttonPanel.add(saveSvgButton);
+
         // 刷新图像按钮
         JButton refreshButton = new JButton("刷新图像");
         refreshButton.addActionListener(e -> {

--- a/src/main/java/com/huq/idea/flow/apidoc/StateDiagramAction.java
+++ b/src/main/java/com/huq/idea/flow/apidoc/StateDiagramAction.java
@@ -2,10 +2,8 @@ package com.huq.idea.flow.apidoc;
 
 import com.huq.idea.flow.apidoc.service.UmlFlowService;
 import com.huq.idea.flow.config.config.IdeaSettings;
-import com.huq.idea.flow.model.CallStack;
-import com.huq.idea.flow.model.MethodDescription;
 import com.huq.idea.flow.util.AiUtils;
-import com.huq.idea.flow.util.MethodUtils;
+import com.huq.idea.flow.util.MyPsiUtil;
 import com.huq.idea.flow.util.PlantUmlRenderException;
 import com.huq.idea.flow.util.PlantUmlRenderer;
 import com.intellij.notification.Notification;
@@ -21,12 +19,12 @@ import com.intellij.openapi.editor.LogicalPosition;
 import com.intellij.openapi.progress.PerformInBackgroundOption;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
-import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.ComboBox;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiJavaFile;
-import com.intellij.psi.PsiMethod;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -35,35 +33,26 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 
 /**
- * Action to generate UML flow diagrams from Java code
+ * Action to generate UML state diagrams from Java code
  *
  * @author huqiang
  * @since 2024/8/10
  */
-public class FlowDiagramAction extends AnAction implements DumbAware {
-    private static final Logger LOG = Logger.getInstance(FlowDiagramAction.class);
-
-    // 存储当前方法，用于在生成流程图时使用
-    private PsiMethod currentMethod;
-
-    // 存储当前项目，用于在生成流程图时使用
-    private Project currentProject;
+public class StateDiagramAction extends AnAction {
+    private static final Logger LOG = Logger.getInstance(StateDiagramAction.class);
 
     @Override
-    public void actionPerformed(AnActionEvent e) {
+    public void actionPerformed(@NotNull AnActionEvent e) {
         Project project = e.getProject();
         if (project == null) {
             return;
         }
 
-        // 保存当前项目
-        this.currentProject = project;
-
         PsiFile psiFile = e.getData(LangDataKeys.PSI_FILE);
         if (!(psiFile instanceof PsiJavaFile)) {
             Notifications.Bus.notify(new Notification(
                     "com.yt.huq.idea",
-                    "流程图生成",
+                    "状态图生成",
                     "此操作仅适用于Java文件",
                     NotificationType.ERROR),
                     project);
@@ -71,89 +60,92 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
         }
 
         Editor editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR);
-        if (editor == null) {
-            return;
+        PsiClass targetClass = null;
+
+        if (editor != null) {
+            // 获取当前光标位置的类
+            targetClass = ReadAction.compute(() -> {
+                LogicalPosition logicalPosition = editor.getCaretModel().getLogicalPosition();
+                int offset = editor.logicalPositionToOffset(logicalPosition);
+                PsiElement element = psiFile.findElementAt(offset);
+                return PsiTreeUtil.getParentOfType(element, PsiClass.class);
+            });
+        } else {
+            // 从文件获取类（例如在项目视图中右键点击）
+            targetClass = ReadAction.compute(() -> {
+                PsiClass[] classes = ((PsiJavaFile) psiFile).getClasses();
+                if (classes.length > 0) {
+                    return classes[0];
+                }
+                return null;
+            });
         }
 
-        // 获取当前光标位置的方法
-        this.currentMethod = ReadAction.compute(() -> {
-            LogicalPosition logicalPosition = editor.getCaretModel().getLogicalPosition();
-            int offset = editor.logicalPositionToOffset(logicalPosition);
-            return MethodUtils.getContainingMethodAtOffset(psiFile, offset);
-        });
-
-        if (this.currentMethod == null) {
+        if (targetClass == null) {
             Notifications.Bus.notify(new Notification(
                     "com.yt.huq.idea",
-                    "流程图生成",
-                    "光标位置未找到方法",
+                    "状态图生成",
+                    "未找到类",
                     NotificationType.ERROR),
                     project);
             return;
         }
 
-        // 首先分析方法调用链
-        CallStack callStack = ReadAction.compute(() -> {
-            EnhancedMethodChainVisitor methodChainVisitor = new EnhancedMethodChainVisitor();
-            return methodChainVisitor.generateMethodChains(currentMethod, null);
-        });
+        final PsiClass currentClass = targetClass;
 
-        // 收集代码
-        String collectedCode = collectCodeFromCallStack(callStack);
+        // 在后台任务中执行耗时的扫描，避免冻结UI
+        new Task.Backgroundable(project, "收集类信息", true, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                indicator.setIndeterminate(true);
+                indicator.setText("正在收集源码...");
 
-        // 显示初始对话框，包含"生成流程"按钮
-        SwingUtilities.invokeLater(() ->
-            showInitialDialog(project, callStack, collectedCode, currentMethod.getClass().getSimpleName()+"."+currentMethod.getName()));
+                // 仅收集当前类的代码即可，因为状态通常集中在枚举或单类中
+                String collectedCode = ReadAction.compute(() -> {
+                    String classCode = currentClass.getText();
+                    if (classCode != null && !classCode.isEmpty()) {
+                        return "\n\n// " + "=".repeat(80) + "\n" +
+                               "// Class: " + currentClass.getQualifiedName() + "\n" +
+                               "// " + "=".repeat(80) + "\n\n" +
+                               classCode;
+                    }
+                    return "";
+                });
+
+                // 显示初始对话框
+                SwingUtilities.invokeLater(() ->
+                    showInitialDialog(project, collectedCode, currentClass.getName()));
+            }
+        }.queue();
     }
 
-    /**
-     * 显示初始对话框，包含"生成流程"按钮
-     */
-    private void showInitialDialog(Project project, CallStack callStack, String collectedCode, String title) {
-        JFrame frame = new JFrame("UML流程图: " + title);
-        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-        frame.setSize(1200, 800);
 
-
-        // 创建选项卡面板
+    private void showInitialDialog(Project project, String collectedCode, String title) {
         JTabbedPane tabbedPane = new JTabbedPane();
-
-        // 创建初始PlantUML选项卡（空白）
-        JPanel plantUmlTab = createInitialPlantUmlTab(project, frame, collectedCode);
+        JPanel plantUmlTab = createInitialPlantUmlTab(project, title, collectedCode);
         tabbedPane.addTab("PlantUML视图", plantUmlTab);
 
-
-        // 底部面板
         JPanel bottomPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         JLabel enhancedLabel = new JLabel();
         enhancedLabel.setForeground(Color.BLUE);
         bottomPanel.add(enhancedLabel);
 
-        // 创建主面板
         JPanel mainPanel = new JPanel(new BorderLayout());
         mainPanel.add(tabbedPane, BorderLayout.CENTER);
         mainPanel.add(bottomPanel, BorderLayout.SOUTH);
 
         UmlFlowService plugin = project.getService(UmlFlowService.class);
-        mainPanel.setName(title);
+        mainPanel.setName(title + " 状态图");
         plugin.addFlow(mainPanel);
-
-//        frame.add(mainPanel);
-//        frame.setVisible(true);
     }
 
-    /**
-     * 创建初始PlantUML选项卡，包含"生成流程"按钮
-     */
-    private JPanel createInitialPlantUmlTab(Project project, JFrame parentFrame, String collectedCode) {
+    private JPanel createInitialPlantUmlTab(Project project, String title, String collectedCode) {
         JPanel panel = new JPanel(new BorderLayout());
 
-        // 创建一个分割面板，左侧显示代码，右侧显示图形
         JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
         splitPane.setDividerLocation(500);
         splitPane.setResizeWeight(0.5);
 
-        // 左侧代码面板
         JPanel codePanel = new JPanel(new BorderLayout());
         JTextArea textArea = new JTextArea();
         textArea.setEditable(true);
@@ -161,29 +153,23 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
         textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));
         codePanel.add(new JScrollPane(textArea), BorderLayout.CENTER);
 
-        // 右侧图形面板（初始为空白）
         JPanel diagramPanel = new JPanel(new BorderLayout());
-        JLabel waitingLabel = new JLabel("点击\"生成流程\"按钮生成流程图", SwingConstants.CENTER);
+        JLabel waitingLabel = new JLabel("点击\"生成状态图\"按钮生成状态图", SwingConstants.CENTER);
         waitingLabel.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 16));
         diagramPanel.add(waitingLabel, BorderLayout.CENTER);
 
-        // 添加到分割面板
         splitPane.setLeftComponent(codePanel);
         splitPane.setRightComponent(diagramPanel);
 
-        // 底部按钮面板
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
 
-        // AI 提供商选择下拉框
-        JLabel providerLabel = new JLabel("AI 提供商:");
+        JLabel providerLabel = new JLabel("AI提供商:");
         java.util.List<IdeaSettings.CustomAiProviderConfig> availableProviders = AiUtils.getCustomProviders();
-        ComboBox<IdeaSettings.CustomAiProviderConfig> providerComboBox = new ComboBox<>(availableProviders.toArray(new IdeaSettings.CustomAiProviderConfig[0]));
+        JComboBox<IdeaSettings.CustomAiProviderConfig> providerComboBox = new JComboBox<>(availableProviders.toArray(new IdeaSettings.CustomAiProviderConfig[0]));
 
-        // 具体模型选择下拉框
         JLabel specificModelLabel = new JLabel("具体模型:");
-        ComboBox<String> specificModelComboBox = new ComboBox<>();
+        JComboBox<String> specificModelComboBox = new JComboBox<>();
 
-        // 监听提供商改变时，更新可用模型列表
         providerComboBox.addActionListener(e -> {
             IdeaSettings.CustomAiProviderConfig selected = (IdeaSettings.CustomAiProviderConfig) providerComboBox.getSelectedItem();
             specificModelComboBox.removeAllItems();
@@ -198,7 +184,6 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
             }
         });
 
-        // 设置默认选择
         if (!availableProviders.isEmpty()) {
             providerComboBox.setSelectedIndex(-1);
             providerComboBox.setSelectedIndex(0);
@@ -221,79 +206,47 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
         buttonPanel.add(specificModelLabel);
         buttonPanel.add(specificModelComboBox);
 
-        // 提示词选择下拉框
-        JLabel promptLabel = new JLabel("提示词:");
-        java.util.List<IdeaSettings.PromptConfig> prompts = IdeaSettings.getInstance().getState().getFlowPrompts();
-        ComboBox<IdeaSettings.PromptConfig> promptComboBox = new ComboBox<>(prompts.toArray(new IdeaSettings.PromptConfig[0]));
-
-        if (!prompts.isEmpty()) {
-            promptComboBox.setSelectedIndex(0);
-        }
-        promptComboBox.setRenderer(new DefaultListCellRenderer() {
-            @Override
-            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
-                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-                if (value instanceof IdeaSettings.PromptConfig) {
-                    setText(((IdeaSettings.PromptConfig) value).getName());
-                }
-                return this;
-            }
-        });
-        buttonPanel.add(promptLabel);
-        buttonPanel.add(promptComboBox);
-
-        // 生成流程按钮
-        JButton generateButton = new JButton("生成流程");
+        JButton generateButton = new JButton("生成状态图");
         generateButton.addActionListener(e -> {
-            // 禁用按钮，防止重复点击
             generateButton.setEnabled(false);
             generateButton.setText("生成中...");
 
-            // 获取选择的AI提供商
             IdeaSettings.CustomAiProviderConfig selectedProvider = (IdeaSettings.CustomAiProviderConfig) providerComboBox.getSelectedItem();
             String selectedModel = (String) specificModelComboBox.getSelectedItem();
 
             if (selectedProvider == null) {
-                LOG.info("No AI provider selected or available");
                 Notifications.Bus.notify(new Notification(
                         "com.yt.huq.idea",
                         "无可用AI模型",
                         "未选择AI提供商或没有可用的AI提供商。请在设置 > UmlFlowAiConfigurable 中配置至少一个提供商",
                         NotificationType.ERROR),
                         project);
-                // 重新启用按钮
                 generateButton.setEnabled(true);
-                generateButton.setText("生成流程");
+                generateButton.setText("生成状态图");
                 return;
             }
             if (IdeaSettings.getInstance().getState().getPlantumlPathVal() == null ||
                     IdeaSettings.getInstance().getState().getPlantumlPathVal().trim().isEmpty()) {
-                LOG.info("PlantUML安装路径未配置，无法渲染流程图");
                 Notifications.Bus.notify(new Notification(
                         "com.yt.huq.idea",
                         "PlantUML路径缺失",
                         "PlantUML路径未配置。请在设置 > UmlFlowAiConfigurable 中设置",
                         NotificationType.ERROR),
                         project);
-                // 重新启用按钮
                 generateButton.setEnabled(true);
-                generateButton.setText("生成流程");
+                generateButton.setText("生成状态图");
                 return;
             }
 
-            // 在后台任务中执行AI调用
-            new Task.Backgroundable(project, "生成流程图", true, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
+            new Task.Backgroundable(project, "生成状态图", true, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
                 @Override
                 public void run(@NotNull ProgressIndicator indicator) {
-                    indicator.setText("正在生成PlantUML流程图...");
+                    indicator.setText("正在生成PlantUML状态图...");
                     indicator.setIndeterminate(true);
 
-                    // 生成PlantUML流程图
-                    IdeaSettings.PromptConfig selectedPromptConfig = (IdeaSettings.PromptConfig) promptComboBox.getSelectedItem();
-                    String flowPromptTemplate = selectedPromptConfig != null ? selectedPromptConfig.getPrompt() : getFlowDiagramPrompt();
-                    String flowPrompt = String.format(flowPromptTemplate, collectedCode);
-                    
-                    // 使用选择的AI模型调用
+                    String stateDiagramPromptTemplate = IdeaSettings.getInstance().getState().getStateDiagramPrompt();
+                    String flowPrompt = String.format(stateDiagramPromptTemplate, collectedCode);
+
                     AiUtils.AiConfig config = new AiUtils.AiConfig(selectedProvider, selectedModel);
                     if (config.getApiKey() == null || config.getApiKey().trim().isEmpty()) {
                         SwingUtilities.invokeLater(() -> {
@@ -307,55 +260,45 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
                         });
                         return;
                     }
-                    
-                    config.setSystemMessage("你是一个专业的PlantUML流程图生成专家，擅长分析Java代码并生成高质量的流程图。")
+
+                    config.setSystemMessage("你是一个专业的PlantUML状态图生成专家，擅长分析Java代码并生成高质量的状态图。")
                           .setTemperature(0.7)
                           .setMaxTokens(8000);
-                    
+
                     AiUtils.AiResponse response = AiUtils.callAi(flowPrompt, config);
-                    String flowDiagram = response.isSuccess() ? response.getContent() : null;
+                    String classDiagram = response.isSuccess() ? response.getContent() : null;
 
+                    if (classDiagram != null && !classDiagram.isEmpty()) {
+                        classDiagram = cleanupUmlResponse(classDiagram);
 
-                    if (flowDiagram != null && !flowDiagram.isEmpty()) {
-                        // 清理响应
-                        flowDiagram = cleanupUmlResponse(flowDiagram);
-
-                        // 更新UI
-                        String finalFlowDiagram = flowDiagram;
+                        String finalClassDiagram = classDiagram;
                         SwingUtilities.invokeLater(() -> {
-                            // 更新文本区域
-                            textArea.setText(finalFlowDiagram);
-
-                            // 更新图形面板
-                            JPanel newDiagramPanel = PlantUmlRenderer.createPlantUmlPanel(finalFlowDiagram);
+                            textArea.setText(finalClassDiagram);
+                            JPanel newDiagramPanel = PlantUmlRenderer.createPlantUmlPanel(finalClassDiagram);
                             splitPane.setRightComponent(newDiagramPanel);
 
-
-                            // 重新启用按钮
                             generateButton.setEnabled(true);
                             generateButton.setText("重新生成");
 
-                            // 刷新UI
                             panel.revalidate();
                             panel.repaint();
                         });
                     } else {
                         SwingUtilities.invokeLater(() -> {
-                            String errorMsg = "生成流程图失败，请检查API设置和网络连接";
+                            String errorMsg = "生成状态图失败，请检查API设置和网络连接";
                             if (response != null && !response.isSuccess() && response.getErrorMessage() != null) {
-                                errorMsg = "生成流程图失败: " + response.getErrorMessage();
+                                errorMsg = "生成状态图失败: " + response.getErrorMessage();
                             }
-                            
+
                             Notifications.Bus.notify(new Notification(
                                     "com.yt.huq.idea",
-                                    "流程图生成",
+                                    "状态图生成",
                                     errorMsg,
                                     NotificationType.ERROR),
                                     project);
 
-                            // 重新启用按钮
                             generateButton.setEnabled(true);
-                            generateButton.setText("生成流程");
+                            generateButton.setText("生成状态图");
                         });
                     }
                 }
@@ -363,7 +306,6 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
         });
         buttonPanel.add(generateButton);
 
-        // 复制按钮
         JButton copyButton = new JButton("复制到剪贴板");
         copyButton.addActionListener(e -> {
             copyToClipboard(textArea.getText());
@@ -376,16 +318,15 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
         });
         buttonPanel.add(copyButton);
 
-        // 保存代码按钮
         JButton saveCodeButton = new JButton("保存代码");
         saveCodeButton.addActionListener(e -> {
-            JFileChooser fileChooser = new JFileChooser();
-            fileChooser.setDialogTitle("保存UML代码");
-            fileChooser.setSelectedFile(new java.io.File(parentFrame.getTitle().replaceAll("[^a-zA-Z0-9]", "_") + ".puml"));
+            com.intellij.openapi.fileChooser.FileChooserDescriptor descriptor =
+                com.intellij.openapi.fileChooser.FileChooserDescriptorFactory.createSingleFolderDescriptor();
+            descriptor.setTitle("选择保存目录");
 
-            int userSelection = fileChooser.showSaveDialog(parentFrame);
-            if (userSelection == JFileChooser.APPROVE_OPTION) {
-                java.io.File fileToSave = fileChooser.getSelectedFile();
+            com.intellij.openapi.vfs.VirtualFile dir = com.intellij.openapi.fileChooser.FileChooser.chooseFile(descriptor, project, null);
+            if (dir != null) {
+                java.io.File fileToSave = new java.io.File(dir.getPath(), title.replaceAll("[^a-zA-Z0-9]", "_") + ".puml");
                 try {
                     java.io.FileWriter writer = new java.io.FileWriter(fileToSave);
                     writer.write(textArea.getText());
@@ -408,10 +349,8 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
         });
         buttonPanel.add(saveCodeButton);
 
-        // 保存图像按钮
         JButton saveImageButton = new JButton("保存图像");
         saveImageButton.addActionListener(e -> {
-            // 检查是否有内容可以保存
             if (textArea.getText().trim().isEmpty() || !textArea.getText().contains("@startuml")) {
                 Notifications.Bus.notify(new Notification(
                         "com.yt.huq.idea",
@@ -422,15 +361,14 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
                 return;
             }
 
-            JFileChooser fileChooser = new JFileChooser();
-            fileChooser.setDialogTitle("保存UML图像");
-            fileChooser.setSelectedFile(new java.io.File(parentFrame.getTitle().replaceAll("[^a-zA-Z0-9]", "_") + ".png"));
+            com.intellij.openapi.fileChooser.FileChooserDescriptor descriptor =
+                com.intellij.openapi.fileChooser.FileChooserDescriptorFactory.createSingleFolderDescriptor();
+            descriptor.setTitle("选择保存目录");
 
-            int userSelection = fileChooser.showSaveDialog(parentFrame);
-            if (userSelection == JFileChooser.APPROVE_OPTION) {
-                java.io.File fileToSave = fileChooser.getSelectedFile();
+            com.intellij.openapi.vfs.VirtualFile dir = com.intellij.openapi.fileChooser.FileChooser.chooseFile(descriptor, project, null);
+            if (dir != null) {
+                java.io.File fileToSave = new java.io.File(dir.getPath(), title.replaceAll("[^a-zA-Z0-9]", "_") + ".png");
                 try {
-                    // 渲染并保存图像
                     byte[] pngData = PlantUmlRenderer.renderPlantUmlToPng(textArea.getText());
                     if (pngData != null) {
                         java.io.FileOutputStream fos = new java.io.FileOutputStream(fileToSave);
@@ -463,10 +401,8 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
         });
         buttonPanel.add(saveImageButton);
 
-        // 保存SVG按钮
         JButton saveSvgButton = new JButton("保存SVG");
         saveSvgButton.addActionListener(e -> {
-            // 检查是否有内容可以保存
             if (textArea.getText().trim().isEmpty() || !textArea.getText().contains("@startuml")) {
                 Notifications.Bus.notify(new Notification(
                         "com.yt.huq.idea",
@@ -477,15 +413,14 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
                 return;
             }
 
-            JFileChooser fileChooser = new JFileChooser();
-            fileChooser.setDialogTitle("保存UML SVG");
-            fileChooser.setSelectedFile(new java.io.File(parentFrame.getTitle().replaceAll("[^a-zA-Z0-9]", "_") + ".svg"));
+            com.intellij.openapi.fileChooser.FileChooserDescriptor descriptor =
+                com.intellij.openapi.fileChooser.FileChooserDescriptorFactory.createSingleFolderDescriptor();
+            descriptor.setTitle("选择保存目录");
 
-            int userSelection = fileChooser.showSaveDialog(parentFrame);
-            if (userSelection == JFileChooser.APPROVE_OPTION) {
-                java.io.File fileToSave = fileChooser.getSelectedFile();
+            com.intellij.openapi.vfs.VirtualFile dir = com.intellij.openapi.fileChooser.FileChooser.chooseFile(descriptor, project, null);
+            if (dir != null) {
+                java.io.File fileToSave = new java.io.File(dir.getPath(), title.replaceAll("[^a-zA-Z0-9]", "_") + ".svg");
                 try {
-                    // 渲染并保存SVG
                     String svgData = PlantUmlRenderer.renderPlantUmlToSvg(textArea.getText());
                     if (svgData != null) {
                         java.io.FileWriter writer = new java.io.FileWriter(fileToSave);
@@ -518,21 +453,13 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
         });
         buttonPanel.add(saveSvgButton);
 
-        // 刷新图像按钮
         JButton refreshButton = new JButton("刷新图像");
         refreshButton.addActionListener(e -> {
-            // 获取当前文本区域的内容
             String updatedUmlContent = textArea.getText();
-
-            // 创建新的图形面板
             JPanel newDiagramPanel = PlantUmlRenderer.createPlantUmlPanel(updatedUmlContent);
-
-            // 替换旧的图形面板
             splitPane.setRightComponent(newDiagramPanel);
             splitPane.revalidate();
             splitPane.repaint();
-
-            // 刷新UI
             panel.revalidate();
             panel.repaint();
         });
@@ -544,25 +471,17 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
         return panel;
     }
 
-
-    /**
-     * 复制文本到剪贴板
-     */
     private void copyToClipboard(String text) {
         StringSelection stringSelection = new StringSelection(text);
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(stringSelection, null);
     }
 
-    /**
-     * 清理UML响应，确保它是有效的PlantUML代码
-     */
     private String cleanupUmlResponse(String umlResponse) {
         if (umlResponse == null || umlResponse.isEmpty()) {
             return umlResponse;
         }
 
-        // 确保以@startuml开始
         if (!umlResponse.startsWith("@startuml")) {
             int startIndex = umlResponse.indexOf("@startuml");
             if (startIndex >= 0) {
@@ -572,10 +491,8 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
             }
         }
 
-        // 确保以@enduml结束
         if (!umlResponse.endsWith("@enduml")) {
             if (umlResponse.contains("@enduml")) {
-                // 截取到最后一个@enduml
                 int endIndex = umlResponse.lastIndexOf("@enduml") + "@enduml".length();
                 umlResponse = umlResponse.substring(0, endIndex);
             } else {
@@ -585,86 +502,4 @@ public class FlowDiagramAction extends AnAction implements DumbAware {
 
         return umlResponse;
     }
-
-
-    /**
-     * 收集方法调用链中的所有代码
-     */
-    private String collectCodeFromCallStack(CallStack callStack) {
-        StringBuilder codeBuilder = new StringBuilder();
-
-        // 添加根方法的代码
-        appendMethodCode(codeBuilder, callStack);
-
-        // 递归添加子方法的代码
-        for (CallStack child : callStack.getChildren()) {
-            collectCodeFromChildCallStack(codeBuilder, child, 1);
-        }
-
-        return codeBuilder.toString();
-    }
-
-    /**
-     * 递归收集子调用栈中的代码
-     */
-    private void collectCodeFromChildCallStack(StringBuilder codeBuilder, CallStack callStack, int depth) {
-        // 限制递归深度，避免代码过多
-        if (depth > 10) {
-            return;
-        }
-        if (!callStack.isRecursive()) {
-            // 添加当前方法的代码
-            appendMethodCode(codeBuilder, callStack);
-        }
-
-        // 递归处理子节点
-        for (CallStack child : callStack.getChildren()) {
-            collectCodeFromChildCallStack(codeBuilder, child, depth + 1);
-        }
-    }
-
-    /**
-     * 将方法的代码添加到构建器中
-     */
-    private void appendMethodCode(StringBuilder codeBuilder, CallStack callStack) {
-        MethodDescription methodDesc = callStack.getMethodDescription();
-        if (methodDesc == null) {
-            return;
-        }
-
-        // 获取方法的完整代码
-        String methodCode = methodDesc.getText();
-        if (methodCode == null || methodCode.isEmpty()) {
-            return;
-        }
-
-        if (codeBuilder.indexOf(methodDesc.buildMethodId()) != -1) {
-            // 如果已经添加过这个方法的代码，就不再重复添加
-            LOG.info("Method already added: " + methodDesc.buildMethodId());
-            return;
-        }
-
-        // 获取类名和方法名
-        String className = methodDesc.getClassName();
-        String methodName = methodDesc.getName();
-
-        // 添加分隔符和方法信息
-        codeBuilder.append("\n\n// ").append("=".repeat(80)).append("\n");
-        codeBuilder.append("// Class: ").append(className).append("\n");
-        codeBuilder.append("// Method: ").append(methodName).append("\n");
-        codeBuilder.append("// token: ").append(methodDesc.buildMethodId()).append("\n");
-
-        // 添加方法代码
-        codeBuilder.append(methodCode);
-        codeBuilder.append("\n// ").append("=".repeat(80)).append("\n\n");
-    }
-
-    /**
-     * 获取流程图提示词
-     */
-    private String getFlowDiagramPrompt() {
-        // 从设置中获取流程图提示词
-        return IdeaSettings.getInstance().getState().getBuildFlowPrompt();
-    }
-
 }

--- a/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
+++ b/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
@@ -131,6 +131,16 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
             "5. 不要包含与代码无关的注释或解释。\n\n" +
             "下面是需要分析的代码：\n%s";
 
+    public static final String DEFAULT_STATE_DIAGRAM_PROMPT = "你是一个UML状态图生成专家。请基于下面提供的Java枚举或类相关的代码，生成一个PlantUML格式的UML状态图。\n" +
+            "请遵循以下规则：\n" +
+            "1. 严格使用PlantUML状态图语法。\n" +
+            "2. 以 `@startuml` 开始，以 `@enduml` 结束。\n" +
+            "3. 识别所有的状态节点，特别是代码中显式定义的常量、枚举值或状态字段。\n" +
+            "4. 如果方法中存在状态转换的逻辑，准确表示状态转换路径。\n" +
+            "5. 包含状态转移的条件或触发事件说明。\n" +
+            "6. 不要包含与代码无关的注释或解释。\n\n" +
+            "下面是需要分析的代码：\n%s";
+
     public static IdeaSettings getInstance() {
         return ApplicationManager.getApplication().getService(IdeaSettings.class);
     }
@@ -235,6 +245,7 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
         private String buildFlowJsonPrompt = DEFAULT_BUILD_FLOW_JSON_PROMPT;
         private String umlSequencePrompt = DEFAULT_UML_SEQUENCE_PROMPT;
         private String classDiagramPrompt = DEFAULT_CLASS_DIAGRAM_PROMPT;
+        private String stateDiagramPrompt = DEFAULT_STATE_DIAGRAM_PROMPT;
         private List<String> relevantClassPatterns = Arrays.asList(
                 "*Impl", "*Service", "*Adapter", "*Api", "*Repository",
                 "*Mapper", "*Manager", "*Controller"
@@ -365,6 +376,14 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
 
         public void setClassDiagramPrompt(String classDiagramPrompt) {
             this.classDiagramPrompt = classDiagramPrompt;
+        }
+
+        public String getStateDiagramPrompt() {
+            return this.stateDiagramPrompt;
+        }
+
+        public void setStateDiagramPrompt(String stateDiagramPrompt) {
+            this.stateDiagramPrompt = stateDiagramPrompt;
         }
 
         /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -109,5 +109,12 @@
       <add-to-group group-id="GenerateGroup" anchor="last"/>
       <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
     </action>
+    <action id="com.huq.idea.flow.StateDiagramAction"
+            class="com.huq.idea.flow.apidoc.StateDiagramAction"
+            text="Generate State Diagram"
+            description="Generates a state diagram from the class or enum structure.">
+      <add-to-group group-id="GenerateGroup" anchor="last"/>
+      <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+    </action>
   </actions>
 </idea-plugin>


### PR DESCRIPTION
This PR enhances the plugin's ease of use and applies it to more scenarios by adding two major features:

1. **State Diagram Generation:** Introduced `StateDiagramAction`, enabling users to generate PlantUML State Diagrams directly from Java enums or classes. This provides valuable insights into state machine logic within the code.
2. **SVG Export:** Added a "Save SVG" button across all diagram interfaces (Flow, Class, Sequence, and State). Since SVGs are vector-based, they provide significantly higher quality for documentation and scaling compared to standard PNGs.

The changes safely utilize the existing AI utilities, PSI read actions, and PlantUML rendering components without introducing regressions. All tests pass locally.

---
*PR created automatically by Jules for task [17698298427396129561](https://jules.google.com/task/17698298427396129561) started by @yisshengyouni*