### PR TITLE
🧪 [testing improvement] Add unit tests for FlowGraphData.fromJson error handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,10 +33,15 @@ dependencies {
   implementation("com.github.javaparser:javaparser-symbol-solver-core:3.26.0")
   implementation("com.squareup.okhttp3:okhttp:4.12.0")
   implementation("com.github.vlsi.mxgraph:jgraphx:4.2.2")
+  testImplementation(platform("org.junit:junit-bom:5.10.0"))
+  testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
 
 tasks {
+  test {
+    useJUnitPlatform()
+  }
   // Set the JVM compatibility versions
   withType<JavaCompile> {
     sourceCompatibility = "17"

--- a/src/main/java/com/huq/idea/flow/model/FlowGraphData.java
+++ b/src/main/java/com/huq/idea/flow/model/FlowGraphData.java
@@ -43,9 +43,13 @@ public class FlowGraphData {
      * 从JSON字符串解析流程图数据
      */
     public static FlowGraphData fromJson(String json) {
+        if (json == null || json.trim().isEmpty()) {
+            return new FlowGraphData();
+        }
         try {
             Gson gson = new Gson();
-            return gson.fromJson(json, FlowGraphData.class);
+            FlowGraphData data = gson.fromJson(json, FlowGraphData.class);
+            return data != null ? data : new FlowGraphData();
         } catch (Exception e) {
             LOG.error(e);
             // 如果解析失败，返回一个空的数据对象

--- a/src/test/java/com/huq/idea/flow/model/FlowGraphDataTest.java
+++ b/src/test/java/com/huq/idea/flow/model/FlowGraphDataTest.java
@@ -1,0 +1,84 @@
+package com.huq.idea.flow.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FlowGraphDataTest {
+
+    @Test
+    public void testFromJson_ValidJson() {
+        String json = """
+                {
+                  "nodes": [
+                    {
+                      "id": "node1",
+                      "label": "Start",
+                      "type": "start"
+                    }
+                  ],
+                  "edges": [
+                    {
+                      "source": "node1",
+                      "target": "node2",
+                      "label": "to"
+                    }
+                  ]
+                }
+                """;
+
+        FlowGraphData data = FlowGraphData.fromJson(json);
+
+        assertNotNull(data);
+        assertEquals(1, data.getNodes().size());
+        assertEquals("node1", data.getNodes().get(0).getId());
+        assertEquals("Start", data.getNodes().get(0).getLabel());
+        assertEquals("start", data.getNodes().get(0).getType());
+
+        assertEquals(1, data.getEdges().size());
+        assertEquals("node1", data.getEdges().get(0).getSource());
+        assertEquals("node2", data.getEdges().get(0).getTarget());
+        assertEquals("to", data.getEdges().get(0).getLabel());
+    }
+
+    @Test
+    public void testFromJson_InvalidJson() {
+        String invalidJson = "{ invalid json }";
+
+        FlowGraphData data = FlowGraphData.fromJson(invalidJson);
+
+        assertNotNull(data);
+        assertTrue(data.getNodes().isEmpty());
+        assertTrue(data.getEdges().isEmpty());
+    }
+
+    @Test
+    public void testFromJson_EmptyJson() {
+        String emptyJson = "";
+
+        FlowGraphData data = FlowGraphData.fromJson(emptyJson);
+
+        assertNotNull(data);
+        assertTrue(data.getNodes().isEmpty());
+        assertTrue(data.getEdges().isEmpty());
+    }
+
+    @Test
+    public void testFromJson_BlankJson() {
+        String blankJson = "   ";
+
+        FlowGraphData data = FlowGraphData.fromJson(blankJson);
+
+        assertNotNull(data);
+        assertTrue(data.getNodes().isEmpty());
+        assertTrue(data.getEdges().isEmpty());
+    }
+
+    @Test
+    public void testFromJson_NullJson() {
+        FlowGraphData data = FlowGraphData.fromJson(null);
+
+        assertNotNull(data);
+        assertTrue(data.getNodes().isEmpty());
+        assertTrue(data.getEdges().isEmpty());
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing tests for the `FlowGraphData.fromJson` error handling. I also refactored the method to be fully null-safe and exception-safe.

📊 **Coverage:** The new tests cover:
- Valid JSON parsing (happy path)
- Invalid JSON parsing (error handling/catch block)
- Empty JSON string
- Blank (whitespace-only) JSON string
- Null JSON input

✨ **Result:** The improvement in test coverage ensures that `FlowGraphData.fromJson` behaves predictably in all edge cases and never returns a `null` object, which increases the reliability of the flow graph data processing.

---
*PR created automatically by Jules for task [12024906500876186915](https://jules.google.com/task/12024906500876186915) started by @yisshengyouni*