### PR TITLE
Align diagram actions UI and isolate prompt configurations

### DIFF
--- a/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
+++ b/src/main/java/com/huq/idea/flow/apidoc/ClassDiagramAction.java
@@ -33,6 +33,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
 import org.jetbrains.annotations.NotNull;
 import com.huq.idea.flow.apidoc.ui.UmlDiagramUIFactory;
+import com.intellij.openapi.ui.ComboBox;
 
 import javax.swing.*;
 import java.awt.*;
@@ -124,10 +125,34 @@ public class ClassDiagramAction extends AnAction {
                 // 显示初始对话框
                 SwingUtilities.invokeLater(() -> {
                     UmlDiagramUIFactory.PromptProvider promptProvider = new UmlDiagramUIFactory.PromptProvider() {
+                        private ComboBox<IdeaSettings.PromptConfig> promptComboBox;
+
                         @Override
                         public String getPrompt(String collectedCode) {
-                            String classDiagramPromptTemplate = IdeaSettings.getInstance().getState().getClassDiagramPrompt();
+                            IdeaSettings.PromptConfig selectedPromptConfig = promptComboBox != null ? (IdeaSettings.PromptConfig) promptComboBox.getSelectedItem() : null;
+                            String classDiagramPromptTemplate = selectedPromptConfig != null ? selectedPromptConfig.getPrompt() : IdeaSettings.getInstance().getState().getClassDiagramPrompt();
                             return String.format(classDiagramPromptTemplate, collectedCode);
+                        }
+
+                        @Override
+                        public JComboBox<IdeaSettings.PromptConfig> getPromptComboBox() {
+                            java.util.List<IdeaSettings.PromptConfig> prompts = IdeaSettings.getInstance().getState().getClassPrompts();
+                            promptComboBox = new ComboBox<>(prompts.toArray(new IdeaSettings.PromptConfig[0]));
+
+                            if (!prompts.isEmpty()) {
+                                promptComboBox.setSelectedIndex(0);
+                            }
+                            promptComboBox.setRenderer(new DefaultListCellRenderer() {
+                                @Override
+                                public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                                    super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                                    if (value instanceof IdeaSettings.PromptConfig) {
+                                        setText(((IdeaSettings.PromptConfig) value).getName());
+                                    }
+                                    return this;
+                                }
+                            });
+                            return promptComboBox;
                         }
                     };
                     UmlDiagramUIFactory.showInitialDialog(project, collectedCode, "UML类图: " + currentClass.getName(), promptProvider, "生成类图");

--- a/src/main/java/com/huq/idea/flow/apidoc/SequenceDiagramAction.java
+++ b/src/main/java/com/huq/idea/flow/apidoc/SequenceDiagramAction.java
@@ -28,6 +28,7 @@ import com.intellij.psi.PsiJavaFile;
 import com.intellij.psi.PsiMethod;
 import org.jetbrains.annotations.NotNull;
 import com.huq.idea.flow.apidoc.ui.UmlDiagramUIFactory;
+import com.intellij.openapi.ui.ComboBox;
 
 import javax.swing.*;
 import java.awt.*;
@@ -104,10 +105,34 @@ public class SequenceDiagramAction extends AnAction implements DumbAware {
             String title = currentMethod.getClass().getSimpleName() + "." + currentMethod.getName();
 
             UmlDiagramUIFactory.PromptProvider promptProvider = new UmlDiagramUIFactory.PromptProvider() {
+                private ComboBox<IdeaSettings.PromptConfig> promptComboBox;
+
                 @Override
                 public String getPrompt(String collectedCode) {
-                    String flowPromptTemplate = getFlowDiagramPrompt();
-                    return String.format(flowPromptTemplate, collectedCode);
+                    IdeaSettings.PromptConfig selectedPromptConfig = promptComboBox != null ? (IdeaSettings.PromptConfig) promptComboBox.getSelectedItem() : null;
+                    String sequencePromptTemplate = selectedPromptConfig != null ? selectedPromptConfig.getPrompt() : getFlowDiagramPrompt();
+                    return String.format(sequencePromptTemplate, collectedCode);
+                }
+
+                @Override
+                public JComboBox<IdeaSettings.PromptConfig> getPromptComboBox() {
+                    java.util.List<IdeaSettings.PromptConfig> prompts = IdeaSettings.getInstance().getState().getSequencePrompts();
+                    promptComboBox = new ComboBox<>(prompts.toArray(new IdeaSettings.PromptConfig[0]));
+
+                    if (!prompts.isEmpty()) {
+                        promptComboBox.setSelectedIndex(0);
+                    }
+                    promptComboBox.setRenderer(new DefaultListCellRenderer() {
+                        @Override
+                        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                            if (value instanceof IdeaSettings.PromptConfig) {
+                                setText(((IdeaSettings.PromptConfig) value).getName());
+                            }
+                            return this;
+                        }
+                    });
+                    return promptComboBox;
                 }
             };
 

--- a/src/main/java/com/huq/idea/flow/apidoc/StateDiagramAction.java
+++ b/src/main/java/com/huq/idea/flow/apidoc/StateDiagramAction.java
@@ -32,11 +32,11 @@ import com.intellij.psi.PsiType;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
 import org.jetbrains.annotations.NotNull;
+import com.huq.idea.flow.apidoc.ui.UmlDiagramUIFactory;
+import com.intellij.openapi.ui.ComboBox;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.StringSelection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -123,8 +123,41 @@ public class StateDiagramAction extends AnAction {
                 String collectedCode = ReadAction.compute(() -> collectCodeFromClasses(associatedClasses));
 
                 // 显示初始对话框
-                SwingUtilities.invokeLater(() ->
-                    showInitialDialog(project, collectedCode, currentClass.getName()));
+                SwingUtilities.invokeLater(() -> {
+                    UmlDiagramUIFactory.PromptProvider promptProvider = new UmlDiagramUIFactory.PromptProvider() {
+                        private ComboBox<IdeaSettings.PromptConfig> promptComboBox;
+
+                        @Override
+                        public String getPrompt(String collectedCode) {
+                            IdeaSettings.PromptConfig selectedPromptConfig = promptComboBox != null ? (IdeaSettings.PromptConfig) promptComboBox.getSelectedItem() : null;
+                            String statePromptTemplate = selectedPromptConfig != null ? selectedPromptConfig.getPrompt() : IdeaSettings.getInstance().getState().getStateDiagramPrompt();
+                            return String.format(statePromptTemplate, collectedCode);
+                        }
+
+                        @Override
+                        public JComboBox<IdeaSettings.PromptConfig> getPromptComboBox() {
+                            java.util.List<IdeaSettings.PromptConfig> prompts = IdeaSettings.getInstance().getState().getStatePrompts();
+                            promptComboBox = new ComboBox<>(prompts.toArray(new IdeaSettings.PromptConfig[0]));
+
+                            if (!prompts.isEmpty()) {
+                                promptComboBox.setSelectedIndex(0);
+                            }
+                            promptComboBox.setRenderer(new DefaultListCellRenderer() {
+                                @Override
+                                public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                                    super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                                    if (value instanceof IdeaSettings.PromptConfig) {
+                                        setText(((IdeaSettings.PromptConfig) value).getName());
+                                    }
+                                    return this;
+                                }
+                            });
+                            return promptComboBox;
+                        }
+                    };
+
+                    UmlDiagramUIFactory.showInitialDialog(project, collectedCode, "UML状态图: " + currentClass.getName(), promptProvider, "生成状态图");
+                });
             }
         }.queue();
     }
@@ -248,336 +281,5 @@ public class StateDiagramAction extends AnAction {
             }
         }
         return codeBuilder.toString();
-    }
-
-    private void showInitialDialog(Project project, String collectedCode, String title) {
-        JTabbedPane tabbedPane = new JTabbedPane();
-        JPanel plantUmlTab = createInitialPlantUmlTab(project, title, collectedCode);
-        tabbedPane.addTab("PlantUML视图", plantUmlTab);
-
-        JPanel bottomPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        JLabel enhancedLabel = new JLabel();
-        enhancedLabel.setForeground(Color.BLUE);
-        bottomPanel.add(enhancedLabel);
-
-        JPanel mainPanel = new JPanel(new BorderLayout());
-        mainPanel.add(tabbedPane, BorderLayout.CENTER);
-        mainPanel.add(bottomPanel, BorderLayout.SOUTH);
-
-        UmlFlowService plugin = project.getService(UmlFlowService.class);
-        mainPanel.setName(title);
-        plugin.addFlow(mainPanel);
-    }
-
-    private JPanel createInitialPlantUmlTab(Project project, String title, String collectedCode) {
-        JPanel panel = new JPanel(new BorderLayout());
-
-        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
-        splitPane.setDividerLocation(500);
-        splitPane.setResizeWeight(0.5);
-
-        JPanel codePanel = new JPanel(new BorderLayout());
-        JTextArea textArea = new JTextArea();
-        textArea.setEditable(true);
-        textArea.setText(collectedCode);
-        textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));
-        codePanel.add(new JScrollPane(textArea), BorderLayout.CENTER);
-
-        JPanel diagramPanel = new JPanel(new BorderLayout());
-        JLabel waitingLabel = new JLabel("点击\"生成状态图\"按钮生成状态图", SwingConstants.CENTER);
-        waitingLabel.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 16));
-        diagramPanel.add(waitingLabel, BorderLayout.CENTER);
-
-        splitPane.setLeftComponent(codePanel);
-        splitPane.setRightComponent(diagramPanel);
-
-        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-
-        JLabel providerLabel = new JLabel("AI提供商:");
-        java.util.List<IdeaSettings.CustomAiProviderConfig> availableProviders = AiUtils.getCustomProviders();
-        JComboBox<IdeaSettings.CustomAiProviderConfig> providerComboBox = new JComboBox<>(availableProviders.toArray(new IdeaSettings.CustomAiProviderConfig[0]));
-
-        JLabel specificModelLabel = new JLabel("具体模型:");
-        JComboBox<String> specificModelComboBox = new JComboBox<>();
-
-        providerComboBox.addActionListener(e -> {
-            IdeaSettings.CustomAiProviderConfig selected = (IdeaSettings.CustomAiProviderConfig) providerComboBox.getSelectedItem();
-            specificModelComboBox.removeAllItems();
-            if (selected != null && selected.getModels() != null) {
-                String[] models = selected.getModels().split(",");
-                for (String model : models) {
-                    specificModelComboBox.addItem(model.trim());
-                }
-                if (models.length > 0) {
-                    specificModelComboBox.setSelectedIndex(0);
-                }
-            }
-        });
-
-        if (!availableProviders.isEmpty()) {
-            providerComboBox.setSelectedIndex(-1);
-            providerComboBox.setSelectedIndex(0);
-        }
-
-        providerComboBox.setRenderer(new DefaultListCellRenderer() {
-            @Override
-            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
-                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-                if (value instanceof IdeaSettings.CustomAiProviderConfig) {
-                    IdeaSettings.CustomAiProviderConfig provider = (IdeaSettings.CustomAiProviderConfig) value;
-                    setText(provider.getName());
-                }
-                return this;
-            }
-        });
-
-        buttonPanel.add(providerLabel);
-        buttonPanel.add(providerComboBox);
-        buttonPanel.add(specificModelLabel);
-        buttonPanel.add(specificModelComboBox);
-
-        JButton generateButton = new JButton("生成状态图");
-        generateButton.addActionListener(e -> {
-            generateButton.setEnabled(false);
-            generateButton.setText("生成中...");
-
-            IdeaSettings.CustomAiProviderConfig selectedProvider = (IdeaSettings.CustomAiProviderConfig) providerComboBox.getSelectedItem();
-            String selectedModel = (String) specificModelComboBox.getSelectedItem();
-
-            if (selectedProvider == null) {
-                Notifications.Bus.notify(new Notification(
-                        "com.yt.huq.idea",
-                        "无可用AI模型",
-                        "未选择AI提供商或没有可用的AI提供商。请在设置 > UmlFlowAiConfigurable 中配置至少一个提供商",
-                        NotificationType.ERROR),
-                        project);
-                generateButton.setEnabled(true);
-                generateButton.setText("生成状态图");
-                return;
-            }
-            if (IdeaSettings.getInstance().getState().getPlantumlPathVal() == null ||
-                    IdeaSettings.getInstance().getState().getPlantumlPathVal().trim().isEmpty()) {
-                Notifications.Bus.notify(new Notification(
-                        "com.yt.huq.idea",
-                        "PlantUML路径缺失",
-                        "PlantUML路径未配置。请在设置 > UmlFlowAiConfigurable 中设置",
-                        NotificationType.ERROR),
-                        project);
-                generateButton.setEnabled(true);
-                generateButton.setText("生成状态图");
-                return;
-            }
-
-            new Task.Backgroundable(project, "生成状态图", true, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
-                @Override
-                public void run(@NotNull ProgressIndicator indicator) {
-                    indicator.setText("正在生成PlantUML状态图...");
-                    indicator.setIndeterminate(true);
-
-                    String stateDiagramPromptTemplate = IdeaSettings.getInstance().getState().getStateDiagramPrompt();
-                    String flowPrompt = String.format(stateDiagramPromptTemplate, collectedCode);
-
-                    AiUtils.AiConfig config = new AiUtils.AiConfig(selectedProvider, selectedModel);
-                    if (config.getApiKey() == null || config.getApiKey().trim().isEmpty()) {
-                        SwingUtilities.invokeLater(() -> {
-                            generateButton.setEnabled(true);
-                            Notifications.Bus.notify(new Notification(
-                                "com.yt.huq.idea",
-                                "API密钥未配置",
-                                "请在设置中为 " + selectedProvider.getName() + " 配置API密钥",
-                                NotificationType.WARNING),
-                                project);
-                        });
-                        return;
-                    }
-
-                    config.setSystemMessage("你是一个专业的PlantUML状态图生成专家，擅长分析Java代码并生成高质量的状态图。")
-                          .setTemperature(0.7)
-                          .setMaxTokens(8000);
-
-                    AiUtils.AiResponse response = AiUtils.callAi(flowPrompt, config);
-                    String stateDiagram = response.isSuccess() ? response.getContent() : null;
-
-                    if (stateDiagram != null && !stateDiagram.isEmpty()) {
-                        stateDiagram = cleanupUmlResponse(stateDiagram);
-
-                        String finalStateDiagram = stateDiagram;
-                        SwingUtilities.invokeLater(() -> {
-                            textArea.setText(finalStateDiagram);
-                            JPanel newDiagramPanel = PlantUmlRenderer.createPlantUmlPanel(finalStateDiagram);
-                            splitPane.setRightComponent(newDiagramPanel);
-
-                            generateButton.setEnabled(true);
-                            generateButton.setText("重新生成");
-
-                            panel.revalidate();
-                            panel.repaint();
-                        });
-                    } else {
-                        SwingUtilities.invokeLater(() -> {
-                            String errorMsg = "生成状态图失败，请检查API设置和网络连接";
-                            if (response != null && !response.isSuccess() && response.getErrorMessage() != null) {
-                                errorMsg = "生成状态图失败: " + response.getErrorMessage();
-                            }
-
-                            Notifications.Bus.notify(new Notification(
-                                    "com.yt.huq.idea",
-                                    "状态图生成",
-                                    errorMsg,
-                                    NotificationType.ERROR),
-                                    project);
-
-                            generateButton.setEnabled(true);
-                            generateButton.setText("生成状态图");
-                        });
-                    }
-                }
-            }.queue();
-        });
-        buttonPanel.add(generateButton);
-
-        JButton copyButton = new JButton("复制到剪贴板");
-        copyButton.addActionListener(e -> {
-            copyToClipboard(textArea.getText());
-            Notifications.Bus.notify(new Notification(
-                    "com.yt.huq.idea",
-                    "UML图表",
-                    "UML图表已复制到剪贴板",
-                    NotificationType.INFORMATION),
-                    project);
-        });
-        buttonPanel.add(copyButton);
-
-        JButton saveCodeButton = new JButton("保存代码");
-        saveCodeButton.addActionListener(e -> {
-            com.intellij.openapi.fileChooser.FileChooserDescriptor descriptor =
-                com.intellij.openapi.fileChooser.FileChooserDescriptorFactory.createSingleFolderDescriptor();
-            descriptor.setTitle("选择保存目录");
-
-            com.intellij.openapi.vfs.VirtualFile dir = com.intellij.openapi.fileChooser.FileChooser.chooseFile(descriptor, project, null);
-            if (dir != null) {
-                java.io.File fileToSave = new java.io.File(dir.getPath(), title.replaceAll("[^a-zA-Z0-9]", "_") + ".puml");
-                try {
-                    java.io.FileWriter writer = new java.io.FileWriter(fileToSave);
-                    writer.write(textArea.getText());
-                    writer.close();
-                    Notifications.Bus.notify(new Notification(
-                            "com.yt.huq.idea",
-                            "UML图表",
-                            "UML代码已保存到 " + fileToSave.getAbsolutePath(),
-                            NotificationType.INFORMATION),
-                            project);
-                } catch (Exception ex) {
-                    Notifications.Bus.notify(new Notification(
-                            "com.yt.huq.idea",
-                            "UML图表",
-                            "保存UML代码失败: " + ex.getMessage(),
-                            NotificationType.ERROR),
-                            project);
-                }
-            }
-        });
-        buttonPanel.add(saveCodeButton);
-
-        JButton saveImageButton = new JButton("保存图像");
-        saveImageButton.addActionListener(e -> {
-            if (textArea.getText().trim().isEmpty() || !textArea.getText().contains("@startuml")) {
-                Notifications.Bus.notify(new Notification(
-                        "com.yt.huq.idea",
-                        "UML图表",
-                        "没有有效的UML图表可以保存",
-                        NotificationType.WARNING),
-                        project);
-                return;
-            }
-
-            com.intellij.openapi.fileChooser.FileChooserDescriptor descriptor =
-                com.intellij.openapi.fileChooser.FileChooserDescriptorFactory.createSingleFolderDescriptor();
-            descriptor.setTitle("选择保存目录");
-
-            com.intellij.openapi.vfs.VirtualFile dir = com.intellij.openapi.fileChooser.FileChooser.chooseFile(descriptor, project, null);
-            if (dir != null) {
-                java.io.File fileToSave = new java.io.File(dir.getPath(), title.replaceAll("[^a-zA-Z0-9]", "_") + ".png");
-                try {
-                    byte[] pngData = PlantUmlRenderer.renderPlantUmlToPng(textArea.getText());
-                    if (pngData != null) {
-                        java.io.FileOutputStream fos = new java.io.FileOutputStream(fileToSave);
-                        fos.write(pngData);
-                        fos.close();
-                        Notifications.Bus.notify(new Notification(
-                                "com.yt.huq.idea",
-                                "UML图表",
-                                "UML图像已保存到 " + fileToSave.getAbsolutePath(),
-                                NotificationType.INFORMATION),
-                                project);
-                    }
-                } catch (PlantUmlRenderException ex) {
-                    LOG.error("Failed to render UML diagram", ex);
-                    Notifications.Bus.notify(new Notification(
-                            "com.yt.huq.idea",
-                            "UML图表",
-                            "渲染UML图像失败: " + ex.getMessage(),
-                            NotificationType.ERROR),
-                            project);
-                } catch (Exception ex) {
-                    Notifications.Bus.notify(new Notification(
-                            "com.yt.huq.idea",
-                            "UML图表",
-                            "保存UML图像失败: " + ex.getMessage(),
-                            NotificationType.ERROR),
-                            project);
-                }
-            }
-        });
-        buttonPanel.add(saveImageButton);
-
-        JButton refreshButton = new JButton("刷新图像");
-        refreshButton.addActionListener(e -> {
-            String updatedUmlContent = textArea.getText();
-            JPanel newDiagramPanel = PlantUmlRenderer.createPlantUmlPanel(updatedUmlContent);
-            splitPane.setRightComponent(newDiagramPanel);
-            splitPane.revalidate();
-            splitPane.repaint();
-            panel.revalidate();
-            panel.repaint();
-        });
-        buttonPanel.add(refreshButton);
-
-        panel.add(splitPane, BorderLayout.CENTER);
-        panel.add(buttonPanel, BorderLayout.SOUTH);
-
-        return panel;
-    }
-
-    private void copyToClipboard(String text) {
-        StringSelection stringSelection = new StringSelection(text);
-        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-        clipboard.setContents(stringSelection, null);
-    }
-
-    private String cleanupUmlResponse(String umlResponse) {
-        if (umlResponse == null || umlResponse.isEmpty()) {
-            return umlResponse;
-        }
-
-        if (!umlResponse.startsWith("@startuml")) {
-            int startIndex = umlResponse.indexOf("@startuml");
-            if (startIndex >= 0) {
-                umlResponse = umlResponse.substring(startIndex);
-            } else {
-                umlResponse = "@startuml\n" + umlResponse;
-            }
-        }
-
-        if (!umlResponse.endsWith("@enduml")) {
-            if (umlResponse.contains("@enduml")) {
-                int endIndex = umlResponse.lastIndexOf("@enduml") + "@enduml".length();
-                umlResponse = umlResponse.substring(0, endIndex);
-            } else {
-                umlResponse = umlResponse + "\n@enduml";
-            }
-        }
-
-        return umlResponse;
     }
 }

--- a/src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java
+++ b/src/main/java/com/huq/idea/flow/config/config/AiConfigurationComponent.java
@@ -24,8 +24,13 @@ public class AiConfigurationComponent {
     private JTextArea flowPromptTextArea;
     private DefaultListModel<String> promptListModel;
     private JList<String> promptList;
-    private List<IdeaSettings.PromptConfig> promptConfigs;
+    private JComboBox<String> diagramTypeComboBox;
+    private List<IdeaSettings.PromptConfig> flowPromptConfigs;
+    private List<IdeaSettings.PromptConfig> classPromptConfigs;
+    private List<IdeaSettings.PromptConfig> sequencePromptConfigs;
+    private List<IdeaSettings.PromptConfig> statePromptConfigs;
     private int currentPromptIndex = -1;
+    private int currentDiagramTypeIndex = 0;
     private JTextArea relevantPatternsArea;
     private JTextArea excludedPatternsArea;
     private JTextArea classRelevantPatternsArea;
@@ -50,11 +55,32 @@ public class AiConfigurationComponent {
     private JTextField aiModelsField;
 
     public void init(IdeaSettings.State state) {
-        // 深拷贝 promptConfigs
-        promptConfigs = new ArrayList<>();
+        // 深拷贝 flowPromptConfigs
+        flowPromptConfigs = new ArrayList<>();
         if (state.getFlowPrompts() != null) {
             for (IdeaSettings.PromptConfig config : state.getFlowPrompts()) {
-                promptConfigs.add(new IdeaSettings.PromptConfig(config.getName(), config.getPrompt()));
+                flowPromptConfigs.add(new IdeaSettings.PromptConfig(config.getName(), config.getPrompt()));
+            }
+        }
+
+        classPromptConfigs = new ArrayList<>();
+        if (state.getClassPrompts() != null) {
+            for (IdeaSettings.PromptConfig config : state.getClassPrompts()) {
+                classPromptConfigs.add(new IdeaSettings.PromptConfig(config.getName(), config.getPrompt()));
+            }
+        }
+
+        sequencePromptConfigs = new ArrayList<>();
+        if (state.getSequencePrompts() != null) {
+            for (IdeaSettings.PromptConfig config : state.getSequencePrompts()) {
+                sequencePromptConfigs.add(new IdeaSettings.PromptConfig(config.getName(), config.getPrompt()));
+            }
+        }
+
+        statePromptConfigs = new ArrayList<>();
+        if (state.getStatePrompts() != null) {
+            for (IdeaSettings.PromptConfig config : state.getStatePrompts()) {
+                statePromptConfigs.add(new IdeaSettings.PromptConfig(config.getName(), config.getPrompt()));
             }
         }
 
@@ -71,14 +97,9 @@ public class AiConfigurationComponent {
         // 设置数据
         plantumlPathVal.setText(state.getPlantumlPathVal());
 
-        promptListModel.clear();
-        for (IdeaSettings.PromptConfig config : promptConfigs) {
-            promptListModel.addElement(config.getName());
-        }
-
-        if (!promptConfigs.isEmpty()) {
-            promptList.setSelectedIndex(0);
-        }
+        // Initialize the prompt list for the default selected tab (index 0)
+        currentDiagramTypeIndex = diagramTypeComboBox.getSelectedIndex();
+        populatePromptListForActiveTab();
 
         relevantPatternsArea.setText(String.join("\n", state.getRelevantClassPatterns()));
         excludedPatternsArea.setText(String.join("\n", state.getExcludedClassPatterns()));
@@ -334,6 +355,13 @@ public class AiConfigurationComponent {
         promptConfigPanel = new JPanel(new BorderLayout());
         promptConfigPanel.setBorder(new TitledBorder("提示词配置"));
 
+        // Top Panel: Diagram Type Selector
+        JPanel topPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        topPanel.add(new JLabel("图表类型: "));
+        diagramTypeComboBox = new JComboBox<>(new String[]{"流程图 (Flow Diagram)", "类图 (Class Diagram)", "时序图 (Sequence Diagram)", "状态图 (State Diagram)"});
+        topPanel.add(diagramTypeComboBox);
+        promptConfigPanel.add(topPanel, BorderLayout.NORTH);
+
         // Left Panel: List of prompts
         JPanel leftPanel = new JPanel(new BorderLayout());
         promptListModel = new DefaultListModel<>();
@@ -370,37 +398,33 @@ public class AiConfigurationComponent {
         splitPane.setDividerLocation(200);
         promptConfigPanel.add(splitPane, BorderLayout.CENTER);
 
-        // Populate promptConfigs from standard places if missing Class/Sequence/State
-        if (promptConfigs.stream().noneMatch(c -> c.getName().equals("Class Diagram"))) {
-            promptConfigs.add(new IdeaSettings.PromptConfig("Class Diagram", IdeaSettings.getInstance().getState().getClassDiagramPrompt()));
-            promptListModel.addElement("Class Diagram");
-        }
-        if (promptConfigs.stream().noneMatch(c -> c.getName().equals("Sequence Diagram"))) {
-            promptConfigs.add(new IdeaSettings.PromptConfig("Sequence Diagram", IdeaSettings.getInstance().getState().getUmlSequencePrompt()));
-            promptListModel.addElement("Sequence Diagram");
-        }
-        if (promptConfigs.stream().noneMatch(c -> c.getName().equals("State Diagram"))) {
-            promptConfigs.add(new IdeaSettings.PromptConfig("State Diagram", IdeaSettings.getInstance().getState().getStateDiagramPrompt()));
-            promptListModel.addElement("State Diagram");
-        }
-        if (promptConfigs.stream().noneMatch(c -> c.getName().equals("Explain Code"))) {
-            promptConfigs.add(new IdeaSettings.PromptConfig("Explain Code", IdeaSettings.getInstance().getState().getExplainCodePrompt()));
-            promptListModel.addElement("Explain Code");
-        }
-
         // Event Listeners
+        diagramTypeComboBox.addActionListener(e -> {
+            int newTypeIndex = diagramTypeComboBox.getSelectedIndex();
+            if (newTypeIndex == currentDiagramTypeIndex) {
+                return;
+            }
+
+            // Save current before switching
+            saveCurrentPrompt();
+
+            // Update the tracked type index to the new one
+            currentDiagramTypeIndex = newTypeIndex;
+
+            populatePromptListForActiveTab();
+        });
+
         promptList.addListSelectionListener(new ListSelectionListener() {
             @Override
             public void valueChanged(ListSelectionEvent e) {
                 if (!e.getValueIsAdjusting()) {
                     // Save previous prompt if we were editing one
-                    if (currentPromptIndex >= 0 && currentPromptIndex < promptConfigs.size()) {
-                        promptConfigs.get(currentPromptIndex).setPrompt(flowPromptTextArea.getText());
-                    }
+                    saveCurrentPrompt();
 
                     currentPromptIndex = promptList.getSelectedIndex();
-                    if (currentPromptIndex >= 0 && currentPromptIndex < promptConfigs.size()) {
-                        flowPromptTextArea.setText(promptConfigs.get(currentPromptIndex).getPrompt());
+                    List<IdeaSettings.PromptConfig> activeConfigs = getActivePromptConfigs();
+                    if (currentPromptIndex >= 0 && currentPromptIndex < activeConfigs.size()) {
+                        flowPromptTextArea.setText(activeConfigs.get(currentPromptIndex).getPrompt());
                         flowPromptTextArea.setEnabled(true);
                     } else {
                         flowPromptTextArea.setText("");
@@ -413,8 +437,16 @@ public class AiConfigurationComponent {
         addButton.addActionListener(e -> {
             String name = JOptionPane.showInputDialog(mainPanel, "请输入新提示词名称:", "添加提示词", JOptionPane.PLAIN_MESSAGE);
             if (name != null && !name.trim().isEmpty()) {
-                IdeaSettings.PromptConfig newConfig = new IdeaSettings.PromptConfig(name.trim(), IdeaSettings.DEFAULT_BUILD_FLOW_PROMPT);
-                promptConfigs.add(newConfig);
+                String defaultPrompt = "";
+                int typeIndex = diagramTypeComboBox.getSelectedIndex();
+                if (typeIndex == 0) defaultPrompt = IdeaSettings.DEFAULT_BUILD_FLOW_PROMPT;
+                else if (typeIndex == 1) defaultPrompt = IdeaSettings.DEFAULT_CLASS_DIAGRAM_PROMPT;
+                else if (typeIndex == 2) defaultPrompt = IdeaSettings.DEFAULT_UML_SEQUENCE_PROMPT;
+                else if (typeIndex == 3) defaultPrompt = IdeaSettings.DEFAULT_STATE_DIAGRAM_PROMPT;
+
+                IdeaSettings.PromptConfig newConfig = new IdeaSettings.PromptConfig(name.trim(), defaultPrompt);
+                List<IdeaSettings.PromptConfig> activeConfigs = getActivePromptConfigs();
+                activeConfigs.add(newConfig);
                 promptListModel.addElement(newConfig.getName());
                 promptList.setSelectedIndex(promptListModel.size() - 1);
             }
@@ -423,13 +455,14 @@ public class AiConfigurationComponent {
         removeButton.addActionListener(e -> {
             int selectedIndex = promptList.getSelectedIndex();
             if (selectedIndex >= 0) {
+                List<IdeaSettings.PromptConfig> activeConfigs = getActivePromptConfigs();
                 // If we are deleting the last item, ensure there is at least one
-                if (promptConfigs.size() <= 1) {
+                if (activeConfigs.size() <= 1) {
                     JOptionPane.showMessageDialog(mainPanel, "必须保留至少一个提示词配置。", "无法删除", JOptionPane.WARNING_MESSAGE);
                     return;
                 }
                 currentPromptIndex = -1; // Prevent saving to the deleted index
-                promptConfigs.remove(selectedIndex);
+                activeConfigs.remove(selectedIndex);
                 promptListModel.remove(selectedIndex);
                 if (selectedIndex >= promptListModel.size()) {
                     promptList.setSelectedIndex(promptListModel.size() - 1);
@@ -442,14 +475,49 @@ public class AiConfigurationComponent {
         renameButton.addActionListener(e -> {
             int selectedIndex = promptList.getSelectedIndex();
             if (selectedIndex >= 0) {
-                String oldName = promptConfigs.get(selectedIndex).getName();
+                List<IdeaSettings.PromptConfig> activeConfigs = getActivePromptConfigs();
+                String oldName = activeConfigs.get(selectedIndex).getName();
                 String newName = JOptionPane.showInputDialog(mainPanel, "请输入新名称:", oldName);
                 if (newName != null && !newName.trim().isEmpty()) {
-                    promptConfigs.get(selectedIndex).setName(newName.trim());
+                    activeConfigs.get(selectedIndex).setName(newName.trim());
                     promptListModel.set(selectedIndex, newName.trim());
                 }
             }
         });
+    }
+
+    private void saveCurrentPrompt() {
+        if (currentPromptIndex >= 0) {
+            List<IdeaSettings.PromptConfig> activeConfigs = getActivePromptConfigs();
+            if (currentPromptIndex < activeConfigs.size()) {
+                activeConfigs.get(currentPromptIndex).setPrompt(flowPromptTextArea.getText());
+            }
+        }
+    }
+
+    private void populatePromptListForActiveTab() {
+        promptListModel.clear();
+        List<IdeaSettings.PromptConfig> activeConfigs = getActivePromptConfigs();
+        for (IdeaSettings.PromptConfig config : activeConfigs) {
+            promptListModel.addElement(config.getName());
+        }
+
+        if (!activeConfigs.isEmpty()) {
+            promptList.setSelectedIndex(0);
+        } else {
+            flowPromptTextArea.setText("");
+            flowPromptTextArea.setEnabled(false);
+            currentPromptIndex = -1;
+        }
+    }
+
+    private List<IdeaSettings.PromptConfig> getActivePromptConfigs() {
+        int index = currentDiagramTypeIndex;
+        if (index == 0) return flowPromptConfigs;
+        else if (index == 1) return classPromptConfigs;
+        else if (index == 2) return sequencePromptConfigs;
+        else if (index == 3) return statePromptConfigs;
+        return flowPromptConfigs;
     }
     
     /**
@@ -601,11 +669,23 @@ public class AiConfigurationComponent {
     }
 
     public List<IdeaSettings.PromptConfig> getFlowPrompts() {
-        // Ensure the current edited text is saved to the active prompt config
-        if (currentPromptIndex >= 0 && currentPromptIndex < promptConfigs.size()) {
-            promptConfigs.get(currentPromptIndex).setPrompt(flowPromptTextArea.getText());
-        }
-        return promptConfigs;
+        saveCurrentPrompt();
+        return flowPromptConfigs;
+    }
+
+    public List<IdeaSettings.PromptConfig> getClassPrompts() {
+        saveCurrentPrompt();
+        return classPromptConfigs;
+    }
+
+    public List<IdeaSettings.PromptConfig> getSequencePrompts() {
+        saveCurrentPrompt();
+        return sequencePromptConfigs;
+    }
+
+    public List<IdeaSettings.PromptConfig> getStatePrompts() {
+        saveCurrentPrompt();
+        return statePromptConfigs;
     }
 
 

--- a/src/main/java/com/huq/idea/flow/config/config/IdeaConfigurable.java
+++ b/src/main/java/com/huq/idea/flow/config/config/IdeaConfigurable.java
@@ -47,6 +47,10 @@ public class IdeaConfigurable implements Configurable {
 
         state.setBuildFlowPrompt(settingsComponent.getBuildFlowPrompt());
         state.setFlowPrompts(settingsComponent.getFlowPrompts());
+        state.setClassPrompts(settingsComponent.getClassPrompts());
+        state.setSequencePrompts(settingsComponent.getSequencePrompts());
+        state.setStatePrompts(settingsComponent.getStatePrompts());
+
         state.setPlantumlPathVal(settingsComponent.getPlantumlPathValue());
         state.setRelevantClassPatterns(settingsComponent.getRelevantPatterns());
         state.setExcludedClassPatterns(settingsComponent.getExcludedPatterns());
@@ -54,18 +58,5 @@ public class IdeaConfigurable implements Configurable {
         state.setClassExcludedClassPatterns(settingsComponent.getClassExcludedPatterns());
         state.setClassDiagramDepth(settingsComponent.getClassDiagramDepth());
         state.setIncludeLibrarySources(settingsComponent.isIncludeLibrarySources());
-
-        // Ensure standard prompts map back correctly
-        for (IdeaSettings.PromptConfig config : state.getFlowPrompts()) {
-            if ("Class Diagram".equals(config.getName())) {
-                state.setClassDiagramPrompt(config.getPrompt());
-            } else if ("Sequence Diagram".equals(config.getName())) {
-                state.setUmlSequencePrompt(config.getPrompt());
-            } else if ("State Diagram".equals(config.getName())) {
-                state.setStateDiagramPrompt(config.getPrompt());
-            } else if ("Explain Code".equals(config.getName())) {
-                state.setExplainCodePrompt(config.getPrompt());
-            }
-        }
     }
 }

--- a/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
+++ b/src/main/java/com/huq/idea/flow/config/config/IdeaSettings.java
@@ -268,6 +268,10 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
         private String buildMethodPrompt = DEFAULT_BUILD_METHOD_PROMPT;
         private String buildFlowPrompt = DEFAULT_BUILD_FLOW_PROMPT;
         private List<PromptConfig> flowPrompts;
+        private List<PromptConfig> classPrompts;
+        private List<PromptConfig> sequencePrompts;
+        private List<PromptConfig> statePrompts;
+
         private String buildFlowJsonPrompt = DEFAULT_BUILD_FLOW_JSON_PROMPT;
         private String umlSequencePrompt = DEFAULT_UML_SEQUENCE_PROMPT;
         private String classDiagramPrompt = DEFAULT_CLASS_DIAGRAM_PROMPT;
@@ -381,6 +385,54 @@ public class IdeaSettings implements PersistentStateComponent<IdeaSettings.State
 
         public void setFlowPrompts(List<PromptConfig> flowPrompts) {
             this.flowPrompts = flowPrompts;
+        }
+
+        public List<PromptConfig> getClassPrompts() {
+            if (classPrompts == null || classPrompts.isEmpty()) {
+                classPrompts = new java.util.ArrayList<>();
+                if (classDiagramPrompt != null && !classDiagramPrompt.isEmpty()) {
+                    classPrompts.add(new PromptConfig("Default", classDiagramPrompt));
+                } else {
+                    classPrompts.add(new PromptConfig("Default", DEFAULT_CLASS_DIAGRAM_PROMPT));
+                }
+            }
+            return classPrompts;
+        }
+
+        public void setClassPrompts(List<PromptConfig> classPrompts) {
+            this.classPrompts = classPrompts;
+        }
+
+        public List<PromptConfig> getSequencePrompts() {
+            if (sequencePrompts == null || sequencePrompts.isEmpty()) {
+                sequencePrompts = new java.util.ArrayList<>();
+                if (umlSequencePrompt != null && !umlSequencePrompt.isEmpty()) {
+                    sequencePrompts.add(new PromptConfig("Default", umlSequencePrompt));
+                } else {
+                    sequencePrompts.add(new PromptConfig("Default", DEFAULT_UML_SEQUENCE_PROMPT));
+                }
+            }
+            return sequencePrompts;
+        }
+
+        public void setSequencePrompts(List<PromptConfig> sequencePrompts) {
+            this.sequencePrompts = sequencePrompts;
+        }
+
+        public List<PromptConfig> getStatePrompts() {
+            if (statePrompts == null || statePrompts.isEmpty()) {
+                statePrompts = new java.util.ArrayList<>();
+                if (stateDiagramPrompt != null && !stateDiagramPrompt.isEmpty()) {
+                    statePrompts.add(new PromptConfig("Default", stateDiagramPrompt));
+                } else {
+                    statePrompts.add(new PromptConfig("Default", DEFAULT_STATE_DIAGRAM_PROMPT));
+                }
+            }
+            return statePrompts;
+        }
+
+        public void setStatePrompts(List<PromptConfig> statePrompts) {
+            this.statePrompts = statePrompts;
         }
 
         public String getBuildFlowJsonPrompt() {


### PR DESCRIPTION
This PR aligns the `StateDiagramAction`, `ClassDiagramAction`, and `SequenceDiagramAction` to have the exact same capabilities as `FlowDiagramAction`.

Specifically:
1. **Source View and PlantUML View:** All diagram actions now use `UmlDiagramUIFactory.showInitialDialog` to provide consistent "Source View" and "PlantUML" tabs.
2. **Custom Prompts:** All diagram actions now support selecting from a list of custom prompts specific to their diagram type via a JComboBox.
3. **Prompt Isolation:** Prompts for different UML types are now isolated in Settings (`AiConfigurationComponent`). Users can switch between "Flow", "Class", "Sequence", and "State" diagram prompt lists, adding and editing prompts specifically tailored for each action without them leaking into other diagram types.

Tests have been run and verified. UI state bugs regarding prompt list switching have been resolved.

---
*PR created automatically by Jules for task [2517171038348388072](https://jules.google.com/task/2517171038348388072) started by @yisshengyouni*